### PR TITLE
Polish example typography and theme handling

### DIFF
--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -1821,8 +1821,8 @@ class _InstallBlockState extends State<_InstallBlock> {
             'flutter pub add reel_text',
             style: Studio.mono(
               size: 13,
-              color: Studio.text,
-              weight: FontWeight.w700,
+              color: Studio.text.withValues(alpha: 0.9),
+              weight: FontWeight.w600,
             ),
           ),
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,9 +17,11 @@ const double _kShellMaxWidth = 1280;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  GoogleFonts.archivoBlack();
-  GoogleFonts.spaceMono();
-  GoogleFonts.spaceMono(fontWeight: FontWeight.w700);
+  GoogleFonts.instrumentSans(fontWeight: FontWeight.w700);
+  GoogleFonts.instrumentSans(fontWeight: FontWeight.w800);
+  GoogleFonts.jetBrainsMono();
+  GoogleFonts.jetBrainsMono(fontWeight: FontWeight.w600);
+  GoogleFonts.jetBrainsMono(fontWeight: FontWeight.w700);
   await GoogleFonts.pendingFonts();
 
   runApp(const ReelTextExampleApp());
@@ -42,13 +44,42 @@ class ReelTextExampleApp extends StatefulWidget {
   State<ReelTextExampleApp> createState() => _ReelTextExampleAppState();
 }
 
-class _ReelTextExampleAppState extends State<ReelTextExampleApp> {
-  var _brightness = Brightness.dark;
+class _ReelTextExampleAppState extends State<ReelTextExampleApp>
+    with WidgetsBindingObserver {
+  Brightness? _brightnessOverride;
+
+  Brightness get _brightness =>
+      _brightnessOverride ??
+      WidgetsBinding.instance.platformDispatcher.platformBrightness;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangePlatformBrightness() {
+    if (_brightnessOverride == null && mounted) {
+      setState(() {});
+    }
+  }
+
+  void _setBrightness(Brightness brightness) {
+    setState(() => _brightnessOverride = brightness);
+  }
 
   @override
   Widget build(BuildContext context) {
+    final brightness = _brightness;
     Studio.fontsEnabled = widget.useGoogleFonts;
-    Studio.brightness = _brightness;
+    Studio.brightness = brightness;
     final scheme = Studio.scheme;
     return MaterialApp(
       title: 'reel_text studio',
@@ -99,8 +130,8 @@ class _ReelTextExampleAppState extends State<ReelTextExampleApp> {
       home: StudioShell(
         autoPlayHero: widget.autoPlayHero,
         loadLiveMetadata: widget.useGoogleFonts,
-        brightness: _brightness,
-        onBrightnessChanged: (value) => setState(() => _brightness = value),
+        brightness: brightness,
+        onBrightnessChanged: _setBrightness,
       ),
     );
   }

--- a/example/lib/recipes_page.dart
+++ b/example/lib/recipes_page.dart
@@ -119,7 +119,16 @@ class _RecipeCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(title, style: Studio.display(size: 16, letterSpacing: 0)),
+          Text(
+            title,
+            style: Studio.mono(
+              size: 12.5,
+              color: Studio.text,
+              height: 1.25,
+              letterSpacing: 0.1,
+              weight: FontWeight.w700,
+            ),
+          ),
           const SizedBox(height: 7),
           Text(blurb, style: Studio.body(size: 12.5)),
           const SizedBox(height: 16),

--- a/example/lib/studio.dart
+++ b/example/lib/studio.dart
@@ -129,24 +129,28 @@ abstract final class Studio {
     return (lighter + 0.05) / (darker + 0.05);
   }
 
-  /// Display face: Archivo Black — single heavy weight, poster energy.
+  /// Display face: Instrument Sans, clean but less generic than Inter.
   static TextStyle display({
     double size = 64,
     Color? color,
     double height = 1.0,
-    double letterSpacing = -1,
+    double letterSpacing = 0,
+    FontWeight weight = FontWeight.w800,
   }) {
     final style = TextStyle(
       color: color ?? text,
       fontSize: size,
       height: height,
       letterSpacing: letterSpacing,
-      fontWeight: FontWeight.w900,
+      fontWeight: weight,
     );
-    return fontsEnabled ? GoogleFonts.archivoBlack(textStyle: style) : style;
+    if (!fontsEnabled) {
+      return style;
+    }
+    return GoogleFonts.instrumentSans(textStyle: style);
   }
 
-  /// Technical face: Space Mono — captions, numbers, code.
+  /// Technical face: JetBrains Mono, crisp for small code and counters.
   static TextStyle mono({
     double size = 12,
     Color? color,
@@ -162,7 +166,7 @@ abstract final class Studio {
       height: height,
       fontFamilyFallback: const ['Menlo', 'Consolas', 'monospace'],
     );
-    return fontsEnabled ? GoogleFonts.spaceMono(textStyle: style) : style;
+    return fontsEnabled ? GoogleFonts.jetBrainsMono(textStyle: style) : style;
   }
 
   /// Body face: system, quiet on purpose.

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -9,11 +9,19 @@ import 'package:reel_text_example/main.dart';
 import 'package:reel_text_example/studio.dart';
 
 void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+  });
+
+  tearDown(() {
+    binding.platformDispatcher.clearPlatformBrightnessTestValue();
+  });
+
   test(
     'showcase package version is loaded from the root pubspec asset',
     () async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-
       final bundledPubspec = await rootBundle.loadString(
         'packages/reel_text/pubspec.yaml',
       );
@@ -148,6 +156,41 @@ void main() {
       Theme.of(tester.element(scaffold)).scaffoldBackgroundColor,
       equals(Studio.background),
     );
+  });
+
+  testWidgets('app follows platform brightness until the theme is toggled', (
+    tester,
+  ) async {
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+
+    await tester.pumpWidget(
+      const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final scaffold = find.byType(Scaffold);
+    expect(Theme.of(tester.element(scaffold)).brightness, Brightness.light);
+    expect(Studio.isLight, isTrue);
+
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    WidgetsBinding.instance.handlePlatformBrightnessChanged();
+    await tester.pumpAndSettle();
+
+    expect(Theme.of(tester.element(scaffold)).brightness, Brightness.dark);
+    expect(Studio.isLight, isFalse);
+
+    await tester.tap(find.byKey(const ValueKey('theme_toggle_button')));
+    await tester.pumpAndSettle();
+
+    expect(Theme.of(tester.element(scaffold)).brightness, Brightness.light);
+    expect(Studio.isLight, isTrue);
+
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    WidgetsBinding.instance.handlePlatformBrightnessChanged();
+    await tester.pumpAndSettle();
+
+    expect(Theme.of(tester.element(scaffold)).brightness, Brightness.light);
+    expect(Studio.isLight, isTrue);
   });
 
   testWidgets(


### PR DESCRIPTION
## Summary
- replace the example display and mono faces with cleaner Google Fonts
- make the example follow platform brightness until the user toggles the theme
- tune install and recipe-card typography

## Tests
- git diff --check
- flutter analyze .
- flutter test test\\widget_test.dart