### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.1
+
+- Fixed horizontal glyph clipping for heavy text styles in both rolling and
+  settled states.
+- Kept animated row sizing on the original interpolated-width behavior while
+  giving individual glyph faces extra paint room.
+- Added regression coverage for glyph paint bleed, bounded alignment, and
+  selection-surface layout.
+
 ## 0.1.0
 
 - Split internal implementation into focused Dart part files while preserving

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/reel_text_glyphs.dart
+++ b/lib/src/reel_text_glyphs.dart
@@ -94,6 +94,7 @@ class _SettledGlyphSlot extends StatelessWidget {
           glyph,
           width: width,
           height: height,
+          horizontalBleed: _horizontalGlyphBleed(height),
           style: style,
           textDirection: textDirection,
           locale: locale,
@@ -148,6 +149,7 @@ class _GlyphSlot extends StatelessWidget {
           slot.to,
           width: metrics.toWidth,
           height: metrics.height,
+          horizontalBleed: _horizontalGlyphBleed(metrics.height),
           style: effectiveToStyle,
           textDirection: textDirection,
           locale: locale,
@@ -190,6 +192,7 @@ class _GlyphSlot extends StatelessWidget {
                       slot.from,
                       width: metrics.fromWidth,
                       height: metrics.height,
+                      horizontalBleed: _horizontalGlyphBleed(metrics.height),
                       style: effectiveFromStyle,
                       textDirection: textDirection,
                       locale: locale,
@@ -207,6 +210,7 @@ class _GlyphSlot extends StatelessWidget {
                     slot.to,
                     width: metrics.toWidth,
                     height: metrics.height,
+                    horizontalBleed: _horizontalGlyphBleed(metrics.height),
                     style: effectiveToStyle.copyWith(color: incomingColor),
                     textDirection: textDirection,
                     locale: locale,
@@ -241,12 +245,14 @@ class _VerticalSlotClipper extends CustomClipper<Rect> {
 }
 
 double _verticalSlotBleed(double height) => math.max(12, height * 0.38);
+double _horizontalGlyphBleed(double height) => math.max(4, height * 0.08);
 
 class _GlyphFace extends StatelessWidget {
   const _GlyphFace(
     this.text, {
     required this.width,
     required this.height,
+    this.horizontalBleed = 0,
     required this.style,
     required this.textDirection,
     required this.locale,
@@ -256,6 +262,7 @@ class _GlyphFace extends StatelessWidget {
   final String text;
   final double width;
   final double height;
+  final double horizontalBleed;
   final TextStyle style;
   final TextDirection textDirection;
   final Locale? locale;
@@ -263,20 +270,26 @@ class _GlyphFace extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return OverflowBox(
-      alignment: _inlineStartAlignment(textDirection),
-      minWidth: width,
-      maxWidth: width,
-      minHeight: height,
-      maxHeight: height,
-      child: Align(
+    final paintWidth = width + horizontalBleed;
+    return SizedBox(
+      width: width,
+      height: height,
+      child: OverflowBox(
         alignment: _inlineStartAlignment(textDirection),
-        child: _GlyphText(
-          text,
-          style: style,
-          textDirection: textDirection,
-          locale: locale,
-          strutStyle: strutStyle,
+        minWidth: paintWidth,
+        maxWidth: paintWidth,
+        minHeight: height,
+        maxHeight: height,
+        child: SizedBox(
+          width: paintWidth,
+          height: height,
+          child: _GlyphText(
+            text,
+            style: style,
+            textDirection: textDirection,
+            locale: locale,
+            strutStyle: strutStyle,
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.1.0
+version: 0.1.1
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -303,6 +303,73 @@ void main() {
     expect(rollingWidth, lessThan(toWidth));
   });
 
+  testWidgets('glyph faces get paint bleed without reserving width', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('paint_bleed_reel');
+    const style = TextStyle(fontSize: 112, fontWeight: FontWeight.w900);
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 240),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+      curve: Curves.linear,
+      bounce: 0,
+      skipUnchanged: false,
+    );
+
+    final painter = TextPainter(
+      text: const TextSpan(text: '0', style: style),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    )..layout();
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: ReelText(text, key: reelKey, style: style, options: options),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(frame(''));
+    await tester.pumpWidget(frame('0'));
+    await tester.pump(const Duration(milliseconds: 80));
+
+    final rollingWidth = tester.getSize(find.byKey(reelKey)).width;
+    final finiteFaceWidths = tester
+        .widgetList<OverflowBox>(find.byType(OverflowBox))
+        .map((box) => box.maxWidth)
+        .whereType<double>()
+        .where((width) => width.isFinite)
+        .toList();
+
+    expect(rollingWidth, greaterThan(0));
+    expect(rollingWidth, lessThan(painter.size.width));
+    expect(finiteFaceWidths, contains(greaterThan(painter.size.width + 3)));
+
+    await tester.pumpAndSettle();
+
+    final settledFaceWidths = tester
+        .widgetList<OverflowBox>(find.byType(OverflowBox))
+        .map((box) => box.maxWidth)
+        .whereType<double>()
+        .where((width) => width.isFinite)
+        .toList();
+
+    expect(
+      tester.getSize(find.byKey(reelKey)).width,
+      closeTo(painter.size.width, 0.01),
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('reel_text_settled_glyphs')))
+          .width,
+      closeTo(painter.size.width, 0.01),
+    );
+    expect(settledFaceWidths, contains(greaterThan(painter.size.width + 3)));
+  });
+
   testWidgets('complex emoji clusters match Text size and roll safely', (
     tester,
   ) async {
@@ -443,9 +510,13 @@ void main() {
     );
 
     final box = tester.getRect(find.byKey(boxKey));
+    final glyphRow = tester.getRect(
+      find.byKey(const ValueKey('reel_text_settled_glyphs')),
+    );
     final visualGlyph = tester.getRect(find.text('👍🏽'));
 
-    expect(visualGlyph.right, closeTo(box.right, 0.01));
+    expect(glyphRow.right, closeTo(box.right, 0.01));
+    expect(visualGlyph.right, greaterThanOrEqualTo(box.right));
   });
 
   testWidgets('rich text keeps styled spans selectable as one text run', (
@@ -723,9 +794,13 @@ void main() {
     );
 
     final box = tester.getRect(find.byKey(boxKey));
+    final glyphRow = tester.getRect(
+      find.byKey(const ValueKey('reel_text_settled_glyphs')),
+    );
     final lastGlyph = tester.getRect(find.text('o'));
 
-    expect(lastGlyph.right, closeTo(box.right, 0.01));
+    expect(glyphRow.right, closeTo(box.right, 0.01));
+    expect(lastGlyph.right, greaterThanOrEqualTo(box.right));
   });
 
   testWidgets('textAlign end keeps Text-like size under loose constraints', (


### PR DESCRIPTION
## Summary
- bump reel_text to 0.1.1
- fix horizontal glyph clipping in rolling and settled states
- document the release and add regression coverage

## Verification
- dart format --output=none --set-exit-if-changed .
- flutter test
- flutter test test\\widget_test.dart (from example)
- flutter analyze .
- flutter pub publish --dry-run