### PR TITLE
Fix mobile top bar actions alignment

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -369,6 +369,7 @@ class _TopBarState extends State<_TopBar> {
           compact: compact,
         );
         final actions = Row(
+          key: const ValueKey('app_bar_actions'),
           mainAxisSize: MainAxisSize.min,
           children: [
             toggle,
@@ -391,7 +392,12 @@ class _TopBarState extends State<_TopBar> {
                       children: [
                         Row(
                           children: [
-                            Flexible(child: brand),
+                            Expanded(
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: brand,
+                              ),
+                            ),
                             const SizedBox(width: 12),
                             actions,
                           ],

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -370,6 +370,28 @@ void main() {
     );
   });
 
+  testWidgets('mobile app bar keeps actions on the right edge', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final topFrame = tester.getRect(
+      find.byKey(const ValueKey('shell_top_bar_frame')),
+    );
+    final title = tester.getRect(find.byKey(const ValueKey('app_bar_title')));
+    final actions = tester.getRect(
+      find.byKey(const ValueKey('app_bar_actions')),
+    );
+
+    expect(title.left, closeTo(topFrame.left + 14, 0.01));
+    expect(actions.right, closeTo(topFrame.right - 14, 0.01));
+    expect(title.right, lessThan(actions.left));
+  });
+
   testWidgets('home try-it strip drives a live ReelText roll', (tester) async {
     await tester.pumpWidget(
       const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),


### PR DESCRIPTION
## Summary
- keep mobile top bar actions pinned to the right edge
- add a mobile regression test for the top bar layout

## Verification
- focused mobile app bar widget test from example
- full example widget test suite
- flutter analyze .