### PR TITLE
[codex] lower reel_text sdk constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.2
+
+- Relaxed the Dart and Flutter SDK constraints to support Flutter 3.16.0 and
+  newer, while keeping the current package implementation unchanged.
+- Documented that the showcase example tracks current stable Flutter separately
+  from the package compatibility floor.
+
 ## 0.1.1
 
 - Fixed horizontal glyph clipping for heavy text styles in both rolling and

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ imperative `flash()` calls stay safe under rapid button taps.
 flutter pub add reel_text
 ```
 
+The package supports Flutter 3.16.0 and newer. The included showcase app tracks
+current stable Flutter because it uses modern demo-only UI APIs.
+
 Then import it:
 
 ```dart
@@ -292,6 +295,9 @@ Run the included example:
 cd example
 flutter run
 ```
+
+The example app is a showcase, not the package compatibility floor; it may use a
+newer Flutter SDK than the library itself.
 
 The example has three pages:
 

--- a/example/README.md
+++ b/example/README.md
@@ -2,6 +2,9 @@
 
 Interactive Flutter example app for the `reel_text` package.
 
+This showcase tracks current stable Flutter. The package itself supports older
+Flutter versions through the root `pubspec.yaml`.
+
 It demonstrates:
 
 - A choreographed Home page for the main motion patterns.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.1.1
+version: 0.1.2
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues
@@ -11,15 +11,15 @@ topics:
   - flutter
 
 environment:
-  sdk: ^3.12.1
-  flutter: ">=3.44.0"
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flutter_lints: ^6.0.0
+  flutter_lints: ">=3.0.0 <7.0.0"
   flutter_test:
     sdk: flutter
 

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -395,7 +395,7 @@ void main() {
                   exitOffset: Duration.zero,
                 ),
               ),
-              ExcludeSemantics(
+              const ExcludeSemantics(
                 child: Text(text, key: textKey, style: style),
               ),
             ],
@@ -438,7 +438,7 @@ void main() {
             mainAxisSize: MainAxisSize.min,
             children: [
               ReelText(reelText, key: reelKey, style: style, options: options),
-              ExcludeSemantics(
+              const ExcludeSemantics(
                 child: Text(text, key: textKey, style: style),
               ),
             ],
@@ -808,7 +808,7 @@ void main() {
   ) async {
     const boxKey = ValueKey('reel_text_loose_alignment_box');
     const reelKey = ValueKey('reel_text_loose_alignment_reel');
-    final constraints = BoxConstraints(maxWidth: 240);
+    const constraints = BoxConstraints(maxWidth: 240);
     const style = TextStyle(fontSize: 32);
     final painter = TextPainter(
       text: const TextSpan(text: 'Go', style: style),


### PR DESCRIPTION
## What changed

- Relaxed the package SDK constraints to Dart `>=3.2.0 <4.0.0` and Flutter `>=3.16.0`.
- Bumped `reel_text` to `0.1.2` and documented the compatibility floor in the README and changelog.
- Kept the example app on current stable Flutter and documented that it is a showcase, not the package compatibility floor.
- Updated the example lockfile for the local path dependency version and added small `const` cleanups needed by the Flutter 3.16 lint set.

## Why

The previous `>=3.12.1` / `>=3.44.0` bounds came from the local Flutter version used to create and test the package, not from a real package requirement. The implementation needs the `TextScaler` era APIs, so Flutter 3.16.0 / Dart 3.2.0 is the conservative lower bound.

## Validation

- `fvm spawn 3.16.0 analyze --no-pub lib test`
- `fvm spawn 3.16.0 test --no-pub test\reel_text_test.dart`
- `flutter analyze`
- `flutter test test\reel_text_test.dart`
- `flutter test test\widget_test.dart` from `example/`
- `dart pub publish --dry-run` -> `Package has 0 warnings.`