### PR TITLE
Release reel_text 0.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ migrate_working_dir/
 .flutter-plugins-dependencies
 /build/
 /coverage/
+example/output/

--- a/.pubignore
+++ b/.pubignore
@@ -6,6 +6,7 @@
 build/
 coverage/
 docs/
+example/output/
 pubspec.lock
 *-audit.log
 web-home-redesign-*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.1.3
+
+- Fixed `DefaultTextStyle.textAlign` inheritance so `ReelText` follows Flutter
+  `Text` layout semantics while internal glyph faces stay anchored inside their
+  paint boxes.
+- Added regression coverage for inherited alignment, internal glyph alignment,
+  empty controller targets, and rapid controller updates.
+- Expanded the README API map and clarified layout, editable text, and example
+  app behavior.
+- Persisted the selected theme in the example app.
+
 ## 0.1.2
 
 - Relaxed the Dart and Flutter SDK constraints to support Flutter 3.16.0 and

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![live demo](https://img.shields.io/badge/demo-live-blue)](https://kicknext.github.io/reel_text/)
 
 Dependency-light Flutter text roll animation for short labels, counters, status
-text, command buttons, rich text, and inline editable text corrections.
+text, command buttons, rich text, and inline editable text corrections. The
+package itself has no runtime dependencies beyond Flutter.
 
 `reel_text` brings the DOM text-roll idea from
 [Danilaa1's original package](https://github.com/Danilaa1/slot-text) to
@@ -22,8 +23,13 @@ imperative `flash()` calls stay safe under rapid button taps.
 flutter pub add reel_text
 ```
 
-The package supports Flutter 3.16.0 and newer. The included showcase app tracks
-current stable Flutter because it uses modern demo-only UI APIs.
+The package supports Dart 3.2.0 and Flutter 3.16.0 and newer. The included
+showcase app tracks current stable Flutter because it uses modern demo-only UI
+APIs.
+
+Only the package root is the compatibility floor. Demo-only dependencies such
+as `http`, `url_launcher`, `flutter_svg`, and `google_fonts` live under
+`example/`.
 
 Then import it:
 
@@ -42,6 +48,19 @@ import 'package:reel_text/reel_text.dart';
 
 Keep it focused on short, high-signal text. Long paragraphs are better left to
 plain `Text`.
+
+## API map
+
+| Need | Use |
+| --- | --- |
+| Declarative one-line text | `ReelText('Copy')` |
+| Styled inline phrase | `ReelText.rich(TextSpan(...))` |
+| Imperative labels | `ReelTextController` with `ReelText.controller` |
+| Temporary button feedback | `ReelTextController.flash()` |
+| Async waiting/success/failure labels | `ReelTextController.runWhile()` |
+| Manual progress or waiting loops | `ReelTextController.startProgress()` or `.startWaiting()` |
+| Rotating labels without a controller | `ReelText.sequence` |
+| Editable inline corrections | `ReelTextEditingController` and `ReelTextEditReplacement` |
 
 ## Quick start
 
@@ -158,6 +177,10 @@ waiting preset. All waiting and progress helpers compile down to the same roll
 engine as normal text changes, so options for direction, curve, stagger, and
 color still apply.
 
+Both `startWaiting()` and `startProgress()` return a `ReelTextProgress` handle.
+Use `complete()`, `fail()`, or `cancel()` to stop the loop, and `isActive` to
+ignore stale async callbacks after another progress loop has taken over.
+
 ## Sequences
 
 Use `ReelText.sequence` when a label should rotate without manually wiring a
@@ -175,8 +198,9 @@ ReelText.sequence(
 
 ## Layout, selection, and emoji
 
-`ReelText` keeps the same single-line layout box as Flutter `Text` for the
-current target string, including during a roll. It does not add extra vertical
+In settled state, `ReelText` keeps the same single-line layout box as Flutter
+`Text` for the current string. During a roll, its width interpolates toward the
+target string while the height stays stable. It does not add extra vertical
 padding for the animation, and heavy text styles get extra horizontal paint
 room so bold glyphs do not clip at slot edges.
 
@@ -214,6 +238,16 @@ ReelText.rich(
 );
 ```
 
+`ReelText.rich` supports `TextSpan` trees. `WidgetSpan` is not supported because
+the widget splits text into measured rolling grapheme clusters.
+
+Because each grapheme cluster gets its own measured slot, Flutter still owns
+the font metrics and emoji clusters, but text shaping is not identical to one
+continuous `Text` run in every script. Latin kerning pairs and ligatures may
+look slightly looser during slot animation, and connected scripts such as
+Arabic should be tested in context before using a roll effect. For short labels,
+counters, statuses, and commands, this tradeoff keeps the motion predictable.
+
 ## Editable text
 
 For editable surfaces, use `ReelTextEditingController`. It extends Flutter's
@@ -236,9 +270,15 @@ controller.animateReplacements(
 );
 ```
 
-The example editor uses this controller with a spell-check pipeline:
-LanguageTool for online suggestions, Flutter's native spellcheck service where
-the platform exposes one, and a deterministic fallback for offline demo text.
+The example app uses this controller in the Editor target input so preset
+labels can roll into place before the text field commits the replacement.
+
+For custom editors, `beginReplacements()` can stage inline replacement widgets,
+`animateReplacements()` rolls them to their target text, `replacementText()`
+previews the committed string, and `commitReplacements()` or
+`clearReplacements()` resolves the edit. Replacement ranges are validated and
+must not overlap. Pass `spanBuilder` to customize the resting text span without
+subclassing the controller.
 
 ## Reduced motion
 
@@ -251,7 +291,8 @@ text instantly instead of rolling. Opt out per widget with
 
 `ReelText` measures glyph slots from the active Flutter text layout. If your app
 loads fonts asynchronously, preload them before the first `ReelText` frame so
-initial slot widths are measured with the final font:
+initial slot widths are measured with the final font. For example, with
+`google_fonts`:
 
 ```dart
 Future<void> main() async {
@@ -270,7 +311,7 @@ Future<void> main() async {
 | `stagger` | `45ms` | Delay between glyph starts. |
 | `duration` | `300ms` | Per-glyph slide duration. |
 | `exitOffset` | `50ms` | Delay before incoming glyphs chase outgoing glyphs. |
-| `curve` | springy cubic | Slide curve. |
+| `curve` | `Cubic(0.34, 1.56, 0.64, 1)` | Slide curve. |
 | `bounce` | `0.6` | Per-glyph timing/tilt variation and settle-overshoot depth. |
 | `color` | null | Flat incoming glyph tint. |
 | `colorBuilder` | null | Per-glyph incoming tint, such as `chromatic()`. |
@@ -296,20 +337,29 @@ cd example
 flutter run
 ```
 
-The example app is a showcase, not the package compatibility floor; it may use a
-newer Flutter SDK than the library itself.
+The example app is a showcase, not the package compatibility floor. It targets
+current stable Flutter separately from the library's Dart 3.2.0 and Flutter
+3.16.0 minimum.
 
-The example has three pages:
+The example has three tabs:
 
 - **Home**: a self-running, choreographed presentation of the core motion
-  patterns.
+  patterns, package metadata, install flow, counters, async labels, and inline
+  correction moments.
 - **Recipes**: live previews with copy-ready code for common integrations.
-- **Editor**: a selectable document where typo corrections roll inline in the
-  body copy.
+- **Editor**: a motion workbench with a target input, direction/color/timing
+  controls, and a `ReelText.controller` preview.
 
 Build the web demo with:
 
 ```bash
 cd example
 flutter build web
+```
+
+For the public GitHub Pages path, build with:
+
+```bash
+cd example
+flutter build web --base-href "/reel_text/"
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -12,7 +12,8 @@ It demonstrates:
 - Imperative button feedback with `ReelTextController.flash()`.
 - Async labels with `runWhile()` and `startWaiting()`.
 - Numeric counters, status pills, rotating labels, and rich text.
-- Inline editable text corrections with `ReelTextEditingController`.
+- A motion workbench with target editing, direction/color/timing controls, and
+  a `ReelText.controller` preview.
 
 Run it with:
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:http/http.dart' as http;
 import 'package:reel_text/reel_text.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'editor_page.dart';
@@ -14,9 +15,12 @@ import 'recipes_page.dart';
 import 'studio.dart';
 
 const double _kShellMaxWidth = 1280;
+const String _kThemePreferenceKey = 'reel_text_example_brightness';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  const themePreferenceStore = ThemePreferenceStore();
+  final savedBrightness = await _loadSavedBrightness(themePreferenceStore);
   GoogleFonts.instrumentSans(fontWeight: FontWeight.w700);
   GoogleFonts.instrumentSans(fontWeight: FontWeight.w800);
   GoogleFonts.jetBrainsMono();
@@ -24,7 +28,43 @@ Future<void> main() async {
   GoogleFonts.jetBrainsMono(fontWeight: FontWeight.w700);
   await GoogleFonts.pendingFonts();
 
-  runApp(const ReelTextExampleApp());
+  runApp(
+    ReelTextExampleApp(
+      initialBrightnessOverride: savedBrightness,
+      themePreferenceStore: themePreferenceStore,
+    ),
+  );
+}
+
+class ThemePreferenceStore {
+  const ThemePreferenceStore();
+
+  Future<Brightness?> loadBrightness() async {
+    final value = await SharedPreferencesAsync().getString(
+      _kThemePreferenceKey,
+    );
+    return switch (value) {
+      'light' => Brightness.light,
+      'dark' => Brightness.dark,
+      _ => null,
+    };
+  }
+
+  Future<void> saveBrightness(Brightness brightness) async {
+    await SharedPreferencesAsync().setString(
+      _kThemePreferenceKey,
+      brightness.name,
+    );
+  }
+}
+
+Future<Brightness?> _loadSavedBrightness(ThemePreferenceStore store) async {
+  try {
+    return await store.loadBrightness();
+  } on Object catch (error) {
+    debugPrint('Could not load saved theme: $error');
+    return null;
+  }
 }
 
 class ReelTextExampleApp extends StatefulWidget {
@@ -32,6 +72,8 @@ class ReelTextExampleApp extends StatefulWidget {
     super.key,
     this.useGoogleFonts = true,
     this.autoPlayHero = true,
+    this.initialBrightnessOverride,
+    this.themePreferenceStore = const ThemePreferenceStore(),
   });
 
   /// Set to false in widget tests to avoid runtime font fetching.
@@ -39,6 +81,9 @@ class ReelTextExampleApp extends StatefulWidget {
 
   /// Set to false in widget tests so the hero stage does not auto-advance.
   final bool autoPlayHero;
+
+  final Brightness? initialBrightnessOverride;
+  final ThemePreferenceStore themePreferenceStore;
 
   @override
   State<ReelTextExampleApp> createState() => _ReelTextExampleAppState();
@@ -55,6 +100,7 @@ class _ReelTextExampleAppState extends State<ReelTextExampleApp>
   @override
   void initState() {
     super.initState();
+    _brightnessOverride = widget.initialBrightnessOverride;
     WidgetsBinding.instance.addObserver(this);
   }
 
@@ -73,6 +119,15 @@ class _ReelTextExampleAppState extends State<ReelTextExampleApp>
 
   void _setBrightness(Brightness brightness) {
     setState(() => _brightnessOverride = brightness);
+    unawaited(_saveBrightness(brightness));
+  }
+
+  Future<void> _saveBrightness(Brightness brightness) async {
+    try {
+      await widget.themePreferenceStore.saveBrightness(brightness);
+    } on Object catch (error) {
+      debugPrint('Could not save theme: $error');
+    }
   }
 
   @override

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -350,7 +358,63 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.1.3"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.26"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: "direct dev"
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,12 +14,14 @@ dependencies:
   http: ^1.6.0
   reel_text:
     path: ..
+  shared_preferences: ^2.5.5
   url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  shared_preferences_platform_interface: ^2.4.2
 
 flutter:
   uses-material-design: true

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -7,12 +7,16 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:reel_text/reel_text.dart';
 import 'package:reel_text_example/main.dart';
 import 'package:reel_text_example/studio.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 void main() {
   final binding = TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
     binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
   });
 
   tearDown(() {
@@ -188,6 +192,43 @@ void main() {
     tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     WidgetsBinding.instance.handlePlatformBrightnessChanged();
     await tester.pumpAndSettle();
+
+    expect(Theme.of(tester.element(scaffold)).brightness, Brightness.light);
+    expect(Studio.isLight, isTrue);
+  });
+
+  testWidgets('app restores the saved theme choice', (tester) async {
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    const store = ThemePreferenceStore();
+
+    Future<void> pumpExample() async {
+      await tester.pumpWidget(
+        ReelTextExampleApp(
+          useGoogleFonts: false,
+          autoPlayHero: false,
+          initialBrightnessOverride: await store.loadBrightness(),
+          themePreferenceStore: store,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+
+    await pumpExample();
+
+    final scaffold = find.byType(Scaffold);
+    expect(Theme.of(tester.element(scaffold)).brightness, Brightness.dark);
+
+    await tester.tap(find.byKey(const ValueKey('theme_toggle_button')));
+    await tester.pumpAndSettle();
+
+    expect(Theme.of(tester.element(scaffold)).brightness, Brightness.light);
+    expect(await store.loadBrightness(), Brightness.light);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    await pumpExample();
 
     expect(Theme.of(tester.element(scaffold)).brightness, Brightness.light);
     expect(Studio.isLight, isTrue);

--- a/lib/src/reel_text_glyphs.dart
+++ b/lib/src/reel_text_glyphs.dart
@@ -317,6 +317,7 @@ class _GlyphText extends StatelessWidget {
       text,
       style: style,
       textDirection: textDirection,
+      textAlign: TextAlign.start,
       locale: locale,
       strutStyle: strutStyle,
       softWrap: false,

--- a/lib/src/reel_text_widget.dart
+++ b/lib/src/reel_text_widget.dart
@@ -363,8 +363,11 @@ class _ReelTextState extends State<ReelText>
         widget.textDirection ??
         Directionality.maybeOf(context) ??
         TextDirection.ltr;
-    final defaultStyle = DefaultTextStyle.of(context).style;
+    final defaultTextStyle = DefaultTextStyle.of(context);
+    final defaultStyle = defaultTextStyle.style;
     final style = defaultStyle.merge(widget.style);
+    final effectiveTextAlign =
+        widget.textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start;
     final visibleText = _targetText ?? _displayedText;
     final visibleRichText = _targetText == null
         ? _displayedRichText
@@ -401,9 +404,8 @@ class _ReelTextState extends State<ReelText>
         text: plan.toText,
       );
       final height = math.max(fromMetrics.height, toMetrics.height);
-      final textAlign = widget.textAlign ?? TextAlign.start;
       final anchorShrinkingRight =
-          _alignsToRight(textAlign, direction) &&
+          _alignsToRight(effectiveTextAlign, direction) &&
           toMetrics.width < fromMetrics.width;
       child = AnimatedBuilder(
         animation: _controller,
@@ -437,7 +439,7 @@ class _ReelTextState extends State<ReelText>
             child: OverflowBox(
               alignment: anchorShrinkingRight
                   ? _inlineStartAlignment(direction)
-                  : _alignmentForTextAlign(textAlign, direction),
+                  : _alignmentForTextAlign(effectiveTextAlign, direction),
               minWidth: 0,
               maxWidth: double.infinity,
               minHeight: height,
@@ -450,7 +452,7 @@ class _ReelTextState extends State<ReelText>
     }
 
     child = _ReelTextAlignment(
-      textAlign: widget.textAlign ?? TextAlign.start,
+      textAlign: effectiveTextAlign,
       textDirection: direction,
       child: child,
     );
@@ -459,7 +461,7 @@ class _ReelTextState extends State<ReelText>
       label: widget.semanticsLabel ?? visibleText,
       child: _ReelTextSelection(
         content: visibleContent,
-        textAlign: widget.textAlign ?? TextAlign.start,
+        textAlign: effectiveTextAlign,
         textDirection: direction,
         locale: widget.locale,
         strutStyle: widget.strutStyle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.1.2
+version: 0.1.3
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -294,9 +294,8 @@ void main() {
     await tester.pumpWidget(frame('iii'));
     await tester.pump(const Duration(milliseconds: 100));
 
-    final rollingWidth = tester
-        .getSize(find.byKey(const ValueKey('reel_text_rolling')))
-        .width;
+    final rollingWidth =
+        tester.getSize(find.byKey(const ValueKey('reel_text_rolling'))).width;
 
     expect(tester.getSize(find.byKey(reelKey)).width, rollingWidth);
     expect(rollingWidth, greaterThan(fromWidth));
@@ -368,6 +367,35 @@ void main() {
       closeTo(painter.size.width, 0.01),
     );
     expect(settledFaceWidths, contains(greaterThan(painter.size.width + 3)));
+  });
+
+  testWidgets('internal glyph text ignores inherited textAlign', (
+    tester,
+  ) async {
+    const style = TextStyle(fontSize: 112, fontWeight: FontWeight.w900);
+
+    await tester.pumpWidget(
+      const DefaultTextStyle(
+        style: TextStyle(),
+        textAlign: TextAlign.end,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(child: ReelText('0', style: style)),
+        ),
+      ),
+    );
+
+    final glyphTexts = tester
+        .widgetList<Text>(
+          find.descendant(of: find.byType(ReelText), matching: find.text('0')),
+        )
+        .toList();
+
+    expect(glyphTexts, isNotEmpty);
+    expect(
+      glyphTexts.every((text) => text.textAlign == TextAlign.start),
+      isTrue,
+    );
   });
 
   testWidgets('complex emoji clusters match Text size and roll safely', (
@@ -803,6 +831,32 @@ void main() {
     expect(lastGlyph.right, greaterThanOrEqualTo(box.right));
   });
 
+  testWidgets('inherits DefaultTextStyle textAlign for public layout', (
+    tester,
+  ) async {
+    const boxKey = ValueKey('reel_text_inherited_alignment_box');
+
+    await tester.pumpWidget(
+      const DefaultTextStyle(
+        style: TextStyle(fontSize: 32),
+        textAlign: TextAlign.end,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(key: boxKey, width: 240, child: ReelText('Go')),
+          ),
+        ),
+      ),
+    );
+
+    final box = tester.getRect(find.byKey(boxKey));
+    final glyphRow = tester.getRect(
+      find.byKey(const ValueKey('reel_text_settled_glyphs')),
+    );
+
+    expect(glyphRow.right, closeTo(box.right, 0.01));
+  });
+
   testWidgets('textAlign end keeps Text-like size under loose constraints', (
     tester,
   ) async {
@@ -1236,6 +1290,81 @@ void main() {
     final settledWidth = tester.getSize(find.byType(ReelText)).width;
 
     expect(settledWidth, closeTo(lastRollingWidth, 0.01));
+  });
+
+  testWidgets('supports empty text and rolls back from empty targets', (
+    tester,
+  ) async {
+    final controller = ReelTextController(initialText: '');
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: ReelText.controller(
+            controller: controller,
+            options: const ReelTextOptions(
+              duration: Duration(milliseconds: 20),
+              stagger: Duration.zero,
+              exitOffset: Duration.zero,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.value, '');
+    expect(tester.getSize(find.byType(ReelText)).width, 0);
+    expect(find.byKey(const ValueKey('reel_text_settled')), findsOneWidget);
+
+    controller.set('Ready');
+    await tester.pumpAndSettle();
+
+    expect(controller.value, 'Ready');
+    expect(tester.getSize(find.byType(ReelText)).width, greaterThan(0));
+    expect(find.bySemanticsLabel('Ready'), findsOneWidget);
+
+    controller.set('');
+    await tester.pumpAndSettle();
+
+    expect(controller.value, '');
+    expect(tester.getSize(find.byType(ReelText)).width, 0);
+    expect(find.text('Ready'), findsNothing);
+  });
+
+  testWidgets('rapid controller set calls land on the latest value', (
+    tester,
+  ) async {
+    final controller = ReelTextController(initialText: 'one');
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReelText.controller(
+          controller: controller,
+          options: const ReelTextOptions(
+            duration: Duration(milliseconds: 40),
+            stagger: Duration.zero,
+            exitOffset: Duration.zero,
+          ),
+        ),
+      ),
+    );
+
+    controller.set('two');
+    controller.set('three');
+    controller.set('four');
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(controller.value, 'four');
+    expect(find.bySemanticsLabel('four'), findsOneWidget);
+    expect(find.bySemanticsLabel('one'), findsNothing);
+    expect(find.bySemanticsLabel('two'), findsNothing);
+    expect(find.bySemanticsLabel('three'), findsNothing);
   });
 
   testWidgets('controller set cancels a pending flash revert', (tester) async {


### PR DESCRIPTION
## Summary
- Bump reel_text to 0.1.3 and update changelog
- Fix inherited text alignment semantics for ReelText glyph layout
- Refresh README/example docs and persist the example theme choice
- Ignore generated capture output from git/pub archives

## Verification
- flutter test
- dart analyze .
- (cd example; flutter test)
- (cd example; flutter analyze)
- flutter pub publish --dry-run