### PR TITLE
Release reel_text 0.1.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  verify:
+  release_verify:
     runs-on: ubuntu-latest
 
     steps:
@@ -66,7 +66,7 @@ jobs:
         run: dart pub publish --dry-run
 
   publish:
-    needs: verify
+    needs: release_verify
     permissions:
       contents: read
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.1.4
+
 - Added accessibility guideline coverage for the example app across desktop and
   mobile Home, Recipes, and Editor layouts.
 - Improved example tap targets, semantic labels, and text-scale resilience for

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.3"
+    version: "0.1.4"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.1.3
+version: 0.1.4
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues


### PR DESCRIPTION
Release bump created after merging accessibility coverage into main.\n\nValidation:\n- flutter test\n- flutter test (example)\n- flutter analyze\n- flutter analyze (example)\n- dart pub publish --dry-run