### PR TITLE
Release reel_text 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.1.5
+
+- Corrected the 0.1.4 changelog to remove a mixed-bidi fix claim for
+  visual-order work that was reverted before release.
+- No runtime changes.
+
 ## 0.1.4
 
 - Added accessibility guideline coverage for the example app across desktop and
@@ -8,9 +14,7 @@
   top navigation, metadata links, recipe controls, and editor controls.
 - Made `ReelText.rich` respect nested `TextSpan.semanticsLabel` values unless a
   widget-level `semanticsLabel` override is provided.
-- Fixed glyph width measurement for mixed RTL/LTR bidi labels so internal slot
-  widths cannot become negative.
-- Added RTL, mixed bidi, and locale layout regression coverage.
+- Added locale and RTL alignment regression coverage.
 - Added an example RTL script recipe for visually checking right-to-left rolls.
 
 ## 0.1.3

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.4"
+    version: "0.1.5"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.1.4
+version: 0.1.5
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues


### PR DESCRIPTION
## Summary
- publish a 0.1.5 correction release
- remove the 0.1.4 changelog claim for mixed-bidi visual-order work that was reverted before release
- keep the release runtime unchanged

## Verification
- flutter test
- flutter analyze
- flutter test (example)
- flutter analyze (example)
- dart pub publish --dry-run