### PR TITLE
Add RTL and mixed bidi visual order support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Added visual-order glyph layout for RTL and mixed-bidi labels while keeping
+  the existing roll width and alignment model.
+- Built bidi rolls from visual-order slots, aligned from the inline end for RTL,
+  so stable glyphs do not need a separate horizontal correction phase.
+- Added regression coverage and a mixed-bidi example recipe for visual checks.
+
 ## 0.1.5
 
 - Corrected the 0.1.4 changelog to remove a mixed-bidi fix claim for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.1.6
+
 - Added visual-order glyph layout for RTL and mixed-bidi labels while keeping
   the existing roll width and alignment model.
 - Built bidi rolls from visual-order slots, aligned from the inline end for RTL,

--- a/README.md
+++ b/README.md
@@ -245,12 +245,27 @@ Screen readers get one semantic label for the current value. For rich text,
 `TextSpan.semanticsLabel` is respected; pass `semanticsLabel` to `ReelText` when
 the whole rolling label needs a custom spoken value.
 
+RTL and mixed-bidi labels follow Flutter's visual glyph order while keeping
+logical semantics. Use `Directionality` or the widget's `textDirection` when the
+label lives outside an already-directional subtree:
+
+```dart
+Directionality(
+  textDirection: TextDirection.rtl,
+  child: ReelText('ETA 12 דק', textAlign: TextAlign.start),
+);
+```
+
+During a roll, bidi labels are diffed in visual slots instead of applying a
+separate horizontal correction after the glyph replacement.
+
 Because each grapheme cluster gets its own measured slot, Flutter still owns
-the font metrics and emoji clusters, but text shaping is not identical to one
-continuous `Text` run in every script. Latin kerning pairs and ligatures may
-look slightly looser during slot animation, and connected scripts such as
-Arabic should be tested in context before using a roll effect. For short labels,
-counters, statuses, and commands, this tradeoff keeps the motion predictable.
+the font metrics, bidi visual order, and emoji clusters, but text shaping is not
+identical to one continuous `Text` run in every script. Latin kerning pairs and
+ligatures may look slightly looser during slot animation, and connected scripts
+such as Arabic should be tested in context before using a roll effect. For short
+labels, counters, statuses, and commands, this tradeoff keeps the motion
+predictable.
 
 ## Editable text
 
@@ -354,7 +369,8 @@ The example has three tabs:
 - **Home**: a self-running, choreographed presentation of the core motion
   patterns, package metadata, install flow, counters, async labels, and inline
   correction moments.
-- **Recipes**: live previews with copy-ready code for common integrations.
+- **Recipes**: live previews with copy-ready code for common integrations,
+  including RTL and mixed-bidi labels.
 - **Editor**: a motion workbench with a target input, direction/color/timing
   controls, and a `ReelText.controller` preview.
 

--- a/example/lib/recipes_page.dart
+++ b/example/lib/recipes_page.dart
@@ -54,6 +54,12 @@ class RecipesPage extends StatelessWidget {
         code: _spamSafeCode,
       ),
       const _RecipeCard(
+        title: 'Mixed bidi',
+        blurb: 'Latin fragments and numbers keep their visual order in RTL UI.',
+        preview: _MixedBidiPreview(),
+        code: _mixedBidiCode,
+      ),
+      const _RecipeCard(
         title: 'RTL script',
         blurb: 'Right-to-left labels roll through full words without jumping.',
         preview: _RtlPreview(),
@@ -108,16 +114,13 @@ class _RecipeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final compact = MediaQuery.sizeOf(context).width < 880;
-    final previewBox = DecoratedBox(
-      decoration: BoxDecoration(
-        color: Studio.surfaceRaised,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Studio.border),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Center(child: preview),
-      ),
+    final previewBlock = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      child: Center(child: preview),
+    );
+    final desktopPreviewBox = ConstrainedBox(
+      constraints: BoxConstraints(minHeight: _previewHeightForCode(code)),
+      child: previewBlock,
     );
     final codeBox = CodeView(code: code);
 
@@ -139,14 +142,14 @@ class _RecipeCard extends StatelessWidget {
           Text(blurb, style: Studio.body(size: 12.5)),
           const SizedBox(height: 16),
           if (compact) ...[
-            previewBox,
+            previewBlock,
             const SizedBox(height: 12),
             codeBox,
           ] else
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Expanded(flex: 2, child: previewBox),
+                Expanded(flex: 2, child: desktopPreviewBox),
                 const SizedBox(width: 14),
                 Expanded(flex: 3, child: codeBox),
               ],
@@ -155,6 +158,11 @@ class _RecipeCard extends StatelessWidget {
       ),
     );
   }
+}
+
+double _previewHeightForCode(String code) {
+  final lines = '\n'.allMatches(code).length + 1;
+  return (52 + lines * 19.0).clamp(148.0, 380.0);
 }
 
 class _RecipeMotionSlot extends StatelessWidget {
@@ -832,7 +840,102 @@ class _SpamSafePreviewState extends State<_SpamSafePreview> {
 }
 
 // ---------------------------------------------------------------------------
-// 7. RTL script
+// 7. Mixed bidi
+// ---------------------------------------------------------------------------
+
+const _mixedBidiCode = '''
+final label = ReelTextController(initialText: 'ETA 12 דק');
+
+Directionality(
+  textDirection: TextDirection.rtl,
+  child: SizedBox(
+    width: 280,
+    child: ReelText.controller(
+      controller: label,
+      textAlign: TextAlign.start,
+      locale: const Locale('he'),
+    ),
+  ),
+);
+
+// On tap:
+label.set('Gate B4 פתוח');''';
+
+class _MixedBidiPreview extends StatefulWidget {
+  const _MixedBidiPreview();
+
+  @override
+  State<_MixedBidiPreview> createState() => _MixedBidiPreviewState();
+}
+
+class _MixedBidiPreviewState extends State<_MixedBidiPreview> {
+  static const _labels = ['ETA 12 דק', 'ETA 09 דק', 'Gate B4 פתוח'];
+
+  late final ReelTextController _label;
+  var _index = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _label = ReelTextController(initialText: _labels.first);
+  }
+
+  @override
+  void dispose() {
+    _label.dispose();
+    super.dispose();
+  }
+
+  void _roll() {
+    _index = (_index + 1) % _labels.length;
+    _label.set(
+      _labels[_index],
+      options: const ReelTextOptions(direction: ReelTextDirection.up),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _RecipeMotionSlot(
+          slotKey: const ValueKey('recipe_mixed_bidi_motion_slot'),
+          width: 330,
+          height: 62,
+          child: Directionality(
+            key: const ValueKey('recipe_mixed_bidi_directionality'),
+            textDirection: TextDirection.rtl,
+            child: SizedBox(
+              width: 280,
+              child: ReelText.controller(
+                key: const ValueKey('recipe_mixed_bidi_text'),
+                controller: _label,
+                textAlign: TextAlign.start,
+                locale: const Locale('he'),
+                style: TextStyle(
+                  color: Studio.text,
+                  fontSize: 25,
+                  fontWeight: FontWeight.w800,
+                  height: 1.12,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 14),
+        StudioButton(
+          onPressed: _roll,
+          filled: false,
+          child: const Text('Roll mixed'),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 8. RTL script
 // ---------------------------------------------------------------------------
 
 const _rtlCode = '''

--- a/example/lib/studio.dart
+++ b/example/lib/studio.dart
@@ -403,8 +403,7 @@ class _StudioPanelState extends State<StudioPanel> {
 
   @override
   Widget build(BuildContext context) {
-    const outerRadius = 24.0;
-    const innerRadius = 20.0;
+    const radius = 20.0;
     final color = widget.color ?? Studio.surface;
     final borderColor = widget.borderColor ?? Studio.border;
     return MouseRegion(
@@ -414,7 +413,24 @@ class _StudioPanelState extends State<StudioPanel> {
         duration: const Duration(milliseconds: 250),
         curve: Curves.easeOutCubic,
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(outerRadius),
+          color: color,
+          borderRadius: BorderRadius.circular(radius),
+          border: Border.all(
+            color: _isHovered
+                ? borderColor.withValues(alpha: 0.7)
+                : borderColor,
+          ),
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Studio.text.withValues(alpha: _isHovered ? 0.035 : 0.02),
+              Studio.transparent,
+              _isHovered
+                  ? borderColor.withValues(alpha: 0.025)
+                  : Studio.primary.withValues(alpha: 0.014),
+            ],
+          ),
           boxShadow: [
             BoxShadow(
               color: _isHovered
@@ -425,42 +441,7 @@ class _StudioPanelState extends State<StudioPanel> {
             ),
           ],
         ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(outerRadius),
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: Studio.surfaceRaised.withValues(alpha: 0.52),
-              borderRadius: BorderRadius.circular(outerRadius),
-              border: Border.all(
-                color: _isHovered
-                    ? borderColor.withValues(alpha: 0.5)
-                    : Studio.borderBright.withValues(alpha: 0.34),
-              ),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(3),
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  color: color,
-                  borderRadius: BorderRadius.circular(innerRadius),
-                  border: Border.all(color: borderColor),
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      Studio.text.withValues(alpha: _isHovered ? 0.04 : 0.025),
-                      Studio.transparent,
-                      _isHovered
-                          ? borderColor.withValues(alpha: 0.03)
-                          : Studio.primary.withValues(alpha: 0.018),
-                    ],
-                  ),
-                ),
-                child: Padding(padding: widget.padding, child: widget.child),
-              ),
-            ),
-          ),
-        ),
+        child: Padding(padding: widget.padding, child: widget.child),
       ),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.5"
+    version: "0.1.6"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -729,6 +729,41 @@ void main() {
     expect(_semanticButtonWithLabel('Like'), findsNothing);
 
     await tester.dragUntilVisible(
+      find.byKey(const ValueKey('recipe_mixed_bidi_motion_slot')),
+      recipesList,
+      const Offset(0, -120),
+    );
+    expect(slotHeight('recipe_mixed_bidi_motion_slot'), 62);
+    expect(
+      tester
+          .widget<Directionality>(
+            find.byKey(const ValueKey('recipe_mixed_bidi_directionality')),
+          )
+          .textDirection,
+      TextDirection.rtl,
+    );
+    final mixedBidiText = tester.widget<ReelText>(
+      find.byKey(const ValueKey('recipe_mixed_bidi_text')),
+    );
+    expect(mixedBidiText.textAlign, TextAlign.start);
+    expect(mixedBidiText.locale, const Locale('he'));
+
+    final mixedButton = find.ancestor(
+      of: find.text('Roll mixed'),
+      matching: find.byType(OutlinedButton),
+    );
+    expect(mixedButton, findsOneWidget);
+    tester.widget<OutlinedButton>(mixedButton).onPressed!();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('recipe_mixed_bidi_motion_slot')),
+        matching: find.byKey(const ValueKey('reel_text_rolling')),
+      ),
+      findsWidgets,
+    );
+
+    await tester.dragUntilVisible(
       find.byKey(const ValueKey('recipe_rtl_motion_slot')),
       recipesList,
       const Offset(0, -120),
@@ -763,12 +798,14 @@ void main() {
       findsWidgets,
     );
 
-    await tester.dragUntilVisible(
-      find.text('KickNext'),
-      recipesList,
-      const Offset(0, -500),
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('studio_footer')),
+      600,
+      scrollable: find.byType(Scrollable).first,
     );
-    await _expectFooter(tester);
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.byKey(const ValueKey('studio_footer')), findsOneWidget);
+    expect(find.text('KickNext'), findsOneWidget);
   });
 
   testWidgets('editor page tunes ReelText motion', (tester) async {

--- a/lib/src/reel_text_glyphs.dart
+++ b/lib/src/reel_text_glyphs.dart
@@ -27,14 +27,14 @@ class _SettledReelText extends StatelessWidget {
     final glyphRow = Row(
       key: const ValueKey('reel_text_settled_glyphs'),
       mainAxisSize: MainAxisSize.min,
-      textDirection: textDirection,
+      textDirection: TextDirection.ltr,
       children: [
-        for (final (index, glyph) in content.glyphs.indexed)
+        for (final index in runMetrics.visualOrder)
           _SettledGlyphSlot(
-            glyph.text,
+            content.glyphs[index].text,
             width: runMetrics.widthAt(index),
             height: runMetrics.height,
-            style: glyph.style,
+            style: content.glyphs[index].style,
             textDirection: textDirection,
             locale: locale,
             strutStyle: strutStyle,
@@ -131,12 +131,12 @@ class _GlyphSlot extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final metrics = _GlyphMetrics(
-      fromWidth: slot.from.isEmpty ? 0 : fromMetrics.widthAt(slot.index),
-      toWidth: slot.to.isEmpty ? 0 : toMetrics.widthAt(slot.index),
+      fromWidth: slot.from.isEmpty ? 0 : fromMetrics.widthAt(slot.fromIndex),
+      toWidth: slot.to.isEmpty ? 0 : toMetrics.widthAt(slot.toIndex),
       height: math.max(fromMetrics.height, toMetrics.height),
     );
-    final fromStyle = fromContent.glyphAt(slot.index)?.style;
-    final toStyle = toContent.glyphAt(slot.index)?.style;
+    final fromStyle = fromContent.glyphAt(slot.fromIndex)?.style;
+    final toStyle = toContent.glyphAt(slot.toIndex)?.style;
     final effectiveToStyle = toStyle ?? fromStyle ?? const TextStyle();
     final travelDistance =
         metrics.height + _verticalSlotBleed(metrics.height) * 2;
@@ -162,8 +162,7 @@ class _GlyphSlot extends StatelessWidget {
       metrics.toWidth,
       slot.widthT(progressMs),
     )!;
-    final textColor =
-        effectiveToStyle.color ??
+    final textColor = effectiveToStyle.color ??
         DefaultTextStyle.of(context).style.color ??
         Colors.black;
     final incomingColor = slot.color == null

--- a/lib/src/reel_text_metrics.dart
+++ b/lib/src/reel_text_metrics.dart
@@ -3,11 +3,13 @@ part of 'reel_text.dart';
 class _TextRunMetrics {
   const _TextRunMetrics({
     required this.widths,
+    required this.visualOrder,
     required this.width,
     required this.height,
   });
 
   final List<double> widths;
+  final List<int> visualOrder;
   final double width;
   final double height;
 
@@ -46,22 +48,42 @@ class _TextRunMetrics {
     }
 
     final widths = <double>[];
+    final visualLefts = <double>[];
     for (var i = 0; i < chars.length; i++) {
-      widths.add(_glyphWidth(painter, offsets[i], offsets[i + 1]));
+      final bounds = _glyphBounds(painter, offsets[i], offsets[i + 1]);
+      widths.add(bounds.width);
+      visualLefts.add(bounds.left);
     }
 
     final measured = widths.fold<double>(0, (sum, width) => sum + width);
     if (widths.isNotEmpty && (measured - painter.size.width).abs() > 1e-9) {
       final index = widths.lastIndexWhere((width) => width > 0);
       if (index >= 0) {
-        widths[index] =
-            math.max(0, widths[index] + painter.size.width - measured);
+        widths[index] = math.max(
+          0,
+          widths[index] + painter.size.width - measured,
+        );
       }
     }
 
     final totalWidth = widths.fold<double>(0, (sum, width) => sum + width);
+    final visualOrder = [for (var i = 0; i < chars.length; i++) i]
+      ..sort((a, b) {
+        final byLeft = visualLefts[a].compareTo(visualLefts[b]);
+        if (byLeft != 0) {
+          return byLeft;
+        }
+        final byRight = (visualLefts[a] + widths[a]).compareTo(
+          visualLefts[b] + widths[b],
+        );
+        if (byRight != 0) {
+          return byRight;
+        }
+        return a.compareTo(b);
+      });
     return _TextRunMetrics(
       widths: widths,
+      visualOrder: visualOrder,
       width: totalWidth,
       height: painter.size.height,
     );
@@ -73,21 +95,34 @@ class _TextRunMetrics {
         .dx;
   }
 
-  static double _glyphWidth(TextPainter painter, int start, int end) {
+  static _GlyphBounds _glyphBounds(TextPainter painter, int start, int end) {
     final boxes = painter.getBoxesForSelection(
       TextSelection(baseOffset: start, extentOffset: end),
     );
     if (boxes.isNotEmpty) {
-      return boxes.fold<double>(
-        0,
-        (sum, box) => sum + (box.right - box.left).abs(),
-      );
+      var width = 0.0;
+      var left = double.infinity;
+      for (final box in boxes) {
+        width += (box.right - box.left).abs();
+        left = math.min(left, math.min(box.left, box.right));
+      }
+      return _GlyphBounds(width: width, left: left.isFinite ? left : 0);
     }
 
     final startDx = _caretDx(painter, start);
     final endDx = _caretDx(painter, end);
-    return (endDx - startDx).abs();
+    return _GlyphBounds(
+      width: (endDx - startDx).abs(),
+      left: math.min(startDx, endDx),
+    );
   }
+}
+
+class _GlyphBounds {
+  const _GlyphBounds({required this.width, required this.left});
+
+  final double width;
+  final double left;
 }
 
 class _GlyphMetrics {

--- a/lib/src/reel_text_plan.dart
+++ b/lib/src/reel_text_plan.dart
@@ -19,10 +19,17 @@ class _RollPlan {
     required String fromText,
     required String toText,
     required ReelTextOptions options,
+    List<int>? fromVisualOrder,
+    List<int>? toVisualOrder,
+    bool alignVisualOrderFromEnd = false,
   }) {
     final fromChars = fromText.characters.toList();
     final toChars = toText.characters.toList();
-    final maxLen = math.max(fromChars.length, toChars.length);
+    final fromOrder =
+        fromVisualOrder ?? [for (var i = 0; i < fromChars.length; i++) i];
+    final toOrder =
+        toVisualOrder ?? [for (var i = 0; i < toChars.length; i++) i];
+    final maxLen = math.max(fromOrder.length, toOrder.length);
     var maxEndMs = 1;
     // The stagger cascade runs across *changed* slots only, so a diff that
     // touches just the tail (counters, ellipsis dots) starts instantly instead
@@ -31,8 +38,18 @@ class _RollPlan {
     final slots = <_SlotPlan>[];
 
     for (var i = 0; i < maxLen; i++) {
-      final from = i < fromChars.length ? fromChars[i] : '';
-      final to = i < toChars.length ? toChars[i] : '';
+      final fromOrderIndex =
+          alignVisualOrderFromEnd ? i - (maxLen - fromOrder.length) : i;
+      final toOrderIndex =
+          alignVisualOrderFromEnd ? i - (maxLen - toOrder.length) : i;
+      final fromIndex = fromOrderIndex >= 0 && fromOrderIndex < fromOrder.length
+          ? fromOrder[fromOrderIndex]
+          : -1;
+      final toIndex = toOrderIndex >= 0 && toOrderIndex < toOrder.length
+          ? toOrder[toOrderIndex]
+          : -1;
+      final from = fromIndex >= 0 ? fromChars[fromIndex] : '';
+      final to = toIndex >= 0 ? toChars[toIndex] : '';
       final unchanged = from == to && (options.skipUnchanged || from.isEmpty);
       final isTail = to.isEmpty;
       final durationMs = math.max(
@@ -57,8 +74,7 @@ class _RollPlan {
       // outgoing one; an empty slot fills immediately.
       final exitOffsetMs = from.isEmpty ? 0 : options.exitOffset.inMilliseconds;
       final color = options.colorBuilder?.call(i, maxLen) ?? options.color;
-      final endMs =
-          baseMs +
+      final endMs = baseMs +
           exitOffsetMs +
           durationMs +
           (color == null ? 0 : options.colorFade.inMilliseconds);
@@ -69,6 +85,8 @@ class _RollPlan {
       slots.add(
         _SlotPlan(
           index: i,
+          fromIndex: fromIndex,
+          toIndex: toIndex,
           from: from,
           to: to,
           changed: !unchanged,
@@ -99,6 +117,8 @@ class _RollPlan {
 class _SlotPlan {
   const _SlotPlan({
     required this.index,
+    required int fromIndex,
+    required int toIndex,
     required this.from,
     required this.to,
     required this.changed,
@@ -111,9 +131,14 @@ class _SlotPlan {
     required this.color,
     required this.tiltRadians,
     required this.overshoot,
-  });
+  })  : _fromIndex = fromIndex,
+        _toIndex = toIndex;
 
   final int index;
+  // Nullable only for hot reload: slots created before these fields existed
+  // should keep rendering by falling back to the original logical index.
+  final int? _fromIndex;
+  final int? _toIndex;
   final String from;
   final String to;
   final bool changed;
@@ -126,6 +151,10 @@ class _SlotPlan {
   final Color? color;
   final double tiltRadians;
   final double overshoot;
+
+  int get fromIndex => _fromIndex ?? index;
+
+  int get toIndex => _toIndex ?? index;
 
   double outT(double nowMs) => _curved(nowMs, baseMs, durationMs);
 

--- a/lib/src/reel_text_widget.dart
+++ b/lib/src/reel_text_widget.dart
@@ -14,11 +14,11 @@ class ReelText extends StatefulWidget {
     this.strutStyle,
     this.semanticsLabel,
     this.respectDisableAnimations = true,
-  }) : controller = null,
-       richText = null,
-       _sequenceValues = null,
-       _sequenceInterval = null,
-       _sequenceOptionsBuilder = null;
+  })  : controller = null,
+        richText = null,
+        _sequenceValues = null,
+        _sequenceInterval = null,
+        _sequenceOptionsBuilder = null;
 
   /// Creates a declarative reel text widget from a styled [TextSpan] tree.
   ///
@@ -36,11 +36,11 @@ class ReelText extends StatefulWidget {
     this.strutStyle,
     this.semanticsLabel,
     this.respectDisableAnimations = true,
-  }) : text = null,
-       controller = null,
-       _sequenceValues = null,
-       _sequenceInterval = null,
-       _sequenceOptionsBuilder = null;
+  })  : text = null,
+        controller = null,
+        _sequenceValues = null,
+        _sequenceInterval = null,
+        _sequenceOptionsBuilder = null;
 
   /// Creates an imperative reel text widget driven by [controller].
   const ReelText.controller({
@@ -54,11 +54,11 @@ class ReelText extends StatefulWidget {
     this.strutStyle,
     this.semanticsLabel,
     this.respectDisableAnimations = true,
-  }) : text = null,
-       richText = null,
-       _sequenceValues = null,
-       _sequenceInterval = null,
-       _sequenceOptionsBuilder = null;
+  })  : text = null,
+        richText = null,
+        _sequenceValues = null,
+        _sequenceInterval = null,
+        _sequenceOptionsBuilder = null;
 
   /// Creates a reel text widget that cycles through [values] on [interval].
   ///
@@ -77,12 +77,12 @@ class ReelText extends StatefulWidget {
     this.strutStyle,
     this.semanticsLabel,
     this.respectDisableAnimations = true,
-  }) : text = null,
-       richText = null,
-       controller = null,
-       _sequenceValues = values,
-       _sequenceInterval = interval,
-       _sequenceOptionsBuilder = optionsBuilder;
+  })  : text = null,
+        richText = null,
+        controller = null,
+        _sequenceValues = values,
+        _sequenceInterval = interval,
+        _sequenceOptionsBuilder = optionsBuilder;
 
   /// Target text in declarative mode.
   final String? text;
@@ -256,7 +256,7 @@ class _ReelTextState extends State<ReelText>
       final value = values[_sequenceIndex];
       final options =
           widget._sequenceOptionsBuilder?.call(_sequenceIndex, value) ??
-          widget.options;
+              widget.options;
       _rollTo(value, options);
     });
   }
@@ -314,11 +314,7 @@ class _ReelTextState extends State<ReelText>
       return;
     }
 
-    final plan = _RollPlan.create(
-      fromText: _displayedText,
-      toText: text,
-      options: options,
-    );
+    final plan = _createRollPlan(text, richText, options);
 
     setState(() {
       _targetText = text;
@@ -362,8 +358,7 @@ class _ReelTextState extends State<ReelText>
 
   @override
   Widget build(BuildContext context) {
-    final direction =
-        widget.textDirection ??
+    final direction = widget.textDirection ??
         Directionality.maybeOf(context) ??
         TextDirection.ltr;
     final defaultTextStyle = DefaultTextStyle.of(context);
@@ -372,9 +367,8 @@ class _ReelTextState extends State<ReelText>
     final effectiveTextAlign =
         widget.textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start;
     final visibleText = _targetText ?? _displayedText;
-    final visibleRichText = _targetText == null
-        ? _displayedRichText
-        : _targetRichText;
+    final visibleRichText =
+        _targetText == null ? _displayedRichText : _targetRichText;
     final visibleContent = _contentFor(visibleText, visibleRichText, style);
     final visibleSemanticsText = _semanticsTextFor(
       visibleText,
@@ -413,7 +407,7 @@ class _ReelTextState extends State<ReelText>
       final height = math.max(fromMetrics.height, toMetrics.height);
       final anchorShrinkingRight =
           _alignsToRight(effectiveTextAlign, direction) &&
-          toMetrics.width < fromMetrics.width;
+              toMetrics.width < fromMetrics.width;
       child = AnimatedBuilder(
         animation: _controller,
         builder: (context, _) {
@@ -424,7 +418,7 @@ class _ReelTextState extends State<ReelText>
           final rollingRow = Row(
             key: const ValueKey('reel_text_rolling'),
             mainAxisSize: MainAxisSize.min,
-            textDirection: direction,
+            textDirection: TextDirection.ltr,
             children: [
               for (final slot in plan.slots)
                 _GlyphSlot(
@@ -506,6 +500,45 @@ class _ReelTextState extends State<ReelText>
     return _ReelTextContent.rich(richText, style);
   }
 
+  _RollPlan _createRollPlan(
+    String text,
+    InlineSpan? richText,
+    ReelTextOptions options,
+  ) {
+    final direction = widget.textDirection ??
+        Directionality.maybeOf(context) ??
+        TextDirection.ltr;
+    final defaultTextStyle = DefaultTextStyle.of(context);
+    final style = defaultTextStyle.style.merge(widget.style);
+    final fromContent = _contentFor(_displayedText, _displayedRichText, style);
+    final toContent = _contentFor(text, richText, style);
+    final fromMetrics = _TextRunMetrics.of(
+      context: context,
+      span: fromContent.span,
+      textDirection: direction,
+      locale: widget.locale,
+      strutStyle: widget.strutStyle,
+      text: _displayedText,
+    );
+    final toMetrics = _TextRunMetrics.of(
+      context: context,
+      span: toContent.span,
+      textDirection: direction,
+      locale: widget.locale,
+      strutStyle: widget.strutStyle,
+      text: text,
+    );
+
+    return _RollPlan.create(
+      fromText: _displayedText,
+      toText: text,
+      options: options,
+      fromVisualOrder: fromMetrics.visualOrder,
+      toVisualOrder: toMetrics.visualOrder,
+      alignVisualOrderFromEnd: direction == TextDirection.rtl,
+    );
+  }
+
   double _rollingWidth(
     _RollPlan plan,
     _TextRunMetrics fromMetrics,
@@ -513,10 +546,9 @@ class _ReelTextState extends State<ReelText>
     double progressMs,
   ) {
     return plan.slots.fold<double>(0, (sum, slot) {
-      final fromWidth = slot.from.isEmpty
-          ? 0.0
-          : fromMetrics.widthAt(slot.index);
-      final toWidth = slot.to.isEmpty ? 0.0 : toMetrics.widthAt(slot.index);
+      final fromWidth =
+          slot.from.isEmpty ? 0.0 : fromMetrics.widthAt(slot.fromIndex);
+      final toWidth = slot.to.isEmpty ? 0.0 : toMetrics.widthAt(slot.toIndex);
       if (!slot.changed) {
         return sum + toWidth;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.1.5
+version: 0.1.6
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -229,6 +230,344 @@ void main() {
       tester.getSize(find.byKey(textKey)),
     );
   });
+
+  testWidgets('settled mixed bidi glyphs follow Flutter visual order', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('reel_bidi_visual_order');
+    const text = 'ETA 12 שלום';
+    const direction = TextDirection.rtl;
+    const style = TextStyle(fontSize: 32, fontWeight: FontWeight.w700);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: direction,
+        child: Center(
+          child: ReelText(text, key: reelKey, style: style),
+        ),
+      ),
+    );
+
+    expect(
+      _visibleReelGlyphsLeftToRight(tester, find.byKey(reelKey)),
+      _textPainterGlyphsLeftToRight(
+        text: text,
+        style: style,
+        textDirection: direction,
+      ),
+    );
+  });
+
+  testWidgets('mixed bidi roll keeps unchanged glyphs in visual order', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('reel_bidi_rolling_order');
+    const fromText = 'AB שלום';
+    const toText = 'AC שלום';
+    const direction = TextDirection.rtl;
+    const style = TextStyle(fontSize: 32, fontWeight: FontWeight.w700);
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 120),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: direction,
+        child: Center(
+          child: ReelText(text, key: reelKey, style: style, options: options),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(frame(fromText));
+    await tester.pumpWidget(frame(toText));
+    await tester.pump(const Duration(milliseconds: 60));
+
+    final actualStableGlyphs = _visibleReelGlyphsLeftToRight(
+      tester,
+      find.byKey(reelKey),
+    ).where((glyph) => glyph != 'B' && glyph != 'C').toList();
+    final expectedStableGlyphs = _textPainterGlyphsLeftToRight(
+      text: toText,
+      style: style,
+      textDirection: direction,
+    ).where((glyph) => glyph != 'C').toList();
+
+    expect(actualStableGlyphs, expectedStableGlyphs);
+  });
+
+  testWidgets('RTL roll keeps source visual order on its first frame', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('reel_rtl_first_frame_order');
+    const fromText = 'אבגד';
+    const toText = 'אבג';
+    const direction = TextDirection.rtl;
+    const style = TextStyle(fontSize: 34, fontWeight: FontWeight.w700);
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 140),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: direction,
+        child: Center(
+          child: ReelText(text, key: reelKey, style: style, options: options),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(frame(fromText));
+    final sourceOrder = _visibleReelGlyphsLeftToRight(
+      tester,
+      find.byKey(reelKey),
+    );
+
+    await tester.pumpWidget(frame(toText));
+
+    expect(find.byKey(const ValueKey('reel_text_rolling')), findsOneWidget);
+    expect(
+      _visibleReelGlyphsLeftToRight(tester, find.byKey(reelKey)),
+      sourceOrder,
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(
+      _visibleReelGlyphsLeftToRight(tester, find.byKey(reelKey)),
+      _textPainterGlyphsLeftToRight(
+        text: toText,
+        style: style,
+        textDirection: direction,
+      ),
+    );
+  });
+
+  testWidgets('mixed bidi roll keeps source visual order on its first frame', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('reel_mixed_bidi_first_frame_order');
+    const fromText = 'ETA 12 דק';
+    const toText = 'ETA 12';
+    const direction = TextDirection.rtl;
+    const style = TextStyle(fontSize: 32, fontWeight: FontWeight.w700);
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 140),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: direction,
+        child: Center(
+          child: ReelText(text, key: reelKey, style: style, options: options),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(frame(fromText));
+    final sourceOrder = _visibleReelGlyphsLeftToRight(
+      tester,
+      find.byKey(reelKey),
+    );
+
+    await tester.pumpWidget(frame(toText));
+
+    expect(find.byKey(const ValueKey('reel_text_rolling')), findsOneWidget);
+    expect(
+      _visibleReelGlyphsLeftToRight(tester, find.byKey(reelKey)),
+      sourceOrder,
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(
+      _visibleReelGlyphsLeftToRight(tester, find.byKey(reelKey)),
+      _textPainterGlyphsLeftToRight(
+        text: toText,
+        style: style,
+        textDirection: direction,
+      ),
+    );
+  });
+
+  testWidgets(
+    'mixed bidi rolling uses visual slots without positioned correction',
+    (tester) async {
+      const reelKey = ValueKey('reel_mixed_bidi_no_positioned');
+      const fromText = 'ETA 12 דק';
+      const toText = 'ETA 12';
+      const direction = TextDirection.rtl;
+      const style = TextStyle(fontSize: 32, fontWeight: FontWeight.w700);
+      const options = ReelTextOptions(
+        duration: Duration(milliseconds: 140),
+        stagger: Duration.zero,
+        exitOffset: Duration.zero,
+        bounce: 0,
+        colorFade: Duration.zero,
+      );
+
+      Widget frame(String text) {
+        return Directionality(
+          textDirection: direction,
+          child: Center(
+            child: SizedBox(
+              width: 280,
+              child: ReelText(
+                text,
+                key: reelKey,
+                textAlign: TextAlign.start,
+                style: style,
+                options: options,
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(frame(fromText));
+      await tester.pumpWidget(frame(toText));
+
+      expect(find.byKey(const ValueKey('reel_text_rolling')), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(const ValueKey('reel_text_rolling')),
+          matching: find.byType(Positioned),
+        ),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'mixed bidi stable glyphs keep their horizontal positions during roll',
+    (tester) async {
+      const reelKey = ValueKey('reel_mixed_bidi_stable_x');
+      const fromText = 'ETA 12 דק';
+      const toText = 'ETA 12';
+      const direction = TextDirection.rtl;
+      const style = TextStyle(fontSize: 32, fontWeight: FontWeight.w700);
+      const options = ReelTextOptions(
+        duration: Duration(milliseconds: 140),
+        stagger: Duration.zero,
+        exitOffset: Duration.zero,
+      );
+
+      Widget frame(String text) {
+        return Directionality(
+          textDirection: direction,
+          child: Center(
+            child: SizedBox(
+              width: 280,
+              child: ReelText(
+                text,
+                key: reelKey,
+                textAlign: TextAlign.start,
+                style: style,
+                options: options,
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(frame(fromText));
+      await tester.pumpWidget(frame(toText));
+
+      final firstFrame = _visibleReelGlyphPositionsLeftToRight(
+        tester,
+        find.byKey(reelKey),
+      );
+
+      await tester.pump(const Duration(milliseconds: 70));
+
+      final midFrame = _visibleReelGlyphPositionsLeftToRight(
+        tester,
+        find.byKey(reelKey),
+      );
+
+      for (final glyph in ['E', 'T', 'A', '1', '2']) {
+        expect(
+          _leftOfGlyph(midFrame, glyph),
+          closeTo(_leftOfGlyph(firstFrame, glyph), 0.01),
+        );
+      }
+    },
+  );
+
+  testWidgets(
+    'mixed bidi final rolling frame matches settled glyph positions',
+    (tester) async {
+      const reelKey = ValueKey('reel_mixed_bidi_final_x');
+      const fromText = 'ETA 12 דק';
+      const toText = 'ETA 12';
+      const direction = TextDirection.rtl;
+      const style = TextStyle(fontSize: 32, fontWeight: FontWeight.w700);
+      const options = ReelTextOptions(
+        duration: Duration(milliseconds: 140),
+        stagger: Duration.zero,
+        exitOffset: Duration.zero,
+      );
+
+      Widget frame(String text) {
+        return Directionality(
+          textDirection: direction,
+          child: Center(
+            child: SizedBox(
+              width: 280,
+              child: ReelText(
+                text,
+                key: reelKey,
+                textAlign: TextAlign.start,
+                style: style,
+                options: options,
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(frame(fromText));
+      await tester.pumpWidget(frame(toText));
+      await tester.pump(const Duration(milliseconds: 219));
+
+      final finalRollingFrame = _visibleReelGlyphPositionsLeftToRight(
+        tester,
+        find.byKey(reelKey),
+      );
+      final finalRollingGlyphs = [
+        for (final entry in finalRollingFrame) entry.text,
+      ];
+
+      expect(
+        finalRollingGlyphs,
+        _textPainterGlyphsLeftToRight(
+          text: toText,
+          style: style,
+          textDirection: direction,
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final settledFrame = _visibleReelGlyphPositionsLeftToRight(
+        tester,
+        find.byKey(reelKey),
+      );
+
+      for (final glyph in ['E', 'T', 'A', '1', '2']) {
+        expect(
+          _leftOfGlyph(finalRollingFrame, glyph),
+          closeTo(_leftOfGlyph(settledFrame, glyph), 0.01),
+        );
+      }
+    },
+  );
 
   testWidgets('settled layout clamps to bounded width without flex overflow', (
     tester,
@@ -962,6 +1301,45 @@ void main() {
     );
     expect(glyphRow.left, closeTo(box.left, 0.01));
   });
+
+  testWidgets(
+    'textAlign start keeps RTL stable glyph anchored during shrinking roll',
+    (tester) async {
+      const options = ReelTextOptions(
+        duration: Duration(milliseconds: 120),
+        stagger: Duration.zero,
+        exitOffset: Duration.zero,
+      );
+
+      Widget wrap(String text) {
+        return Directionality(
+          textDirection: TextDirection.rtl,
+          child: Center(
+            child: SizedBox(
+              width: 240,
+              child: ReelText(
+                text,
+                textAlign: TextAlign.start,
+                options: options,
+                style: const TextStyle(fontSize: 32),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(wrap('אבגד'));
+      await tester.pumpWidget(wrap('אבג'));
+      await tester.pump(const Duration(milliseconds: 60));
+
+      final duringRight = tester.getRect(find.text('א')).right;
+
+      await tester.pumpAndSettle();
+
+      final settledRight = tester.getRect(find.text('א')).right;
+      expect(duringRight, closeTo(settledRight, 0.01));
+    },
+  );
 
   testWidgets('inherits DefaultTextStyle textAlign for public layout', (
     tester,
@@ -1859,4 +2237,117 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.bySemanticsLabel('Copied'), findsOneWidget);
   });
+}
+
+List<String> _visibleReelGlyphsLeftToRight(WidgetTester tester, Finder scope) {
+  final entries = _visibleReelGlyphPositionsLeftToRight(tester, scope);
+  entries.sort(_compareGlyphPositions);
+  return [for (final entry in entries) entry.text];
+}
+
+List<_GlyphPosition> _visibleReelGlyphPositionsLeftToRight(
+  WidgetTester tester,
+  Finder scope,
+) {
+  final entries = <_GlyphPosition>[];
+  final scopeRect = tester.getRect(scope);
+  final textFinder = find.descendant(of: scope, matching: find.byType(Text));
+
+  for (final element in textFinder.evaluate()) {
+    final widget = element.widget as Text;
+    final text = widget.data;
+    if (text == null || text.trim().isEmpty) {
+      continue;
+    }
+    if (!_isEffectivelyOpaque(element)) {
+      continue;
+    }
+    final rect = tester.getRect(find.byWidget(widget));
+    if (rect.bottom <= scopeRect.top || rect.top >= scopeRect.bottom) {
+      continue;
+    }
+    entries.add(_GlyphPosition(text, rect.left, entries.length));
+  }
+
+  entries.sort(_compareGlyphPositions);
+  return entries;
+}
+
+bool _isEffectivelyOpaque(Element element) {
+  var opaque = true;
+  element.visitAncestorElements((ancestor) {
+    final widget = ancestor.widget;
+    if (widget is Opacity && widget.opacity <= 0.01) {
+      opaque = false;
+      return false;
+    }
+    return true;
+  });
+  return opaque;
+}
+
+double _leftOfGlyph(List<_GlyphPosition> entries, String glyph) {
+  return entries.singleWhere((entry) => entry.text == glyph).left;
+}
+
+List<String> _textPainterGlyphsLeftToRight({
+  required String text,
+  required TextStyle style,
+  required TextDirection textDirection,
+}) {
+  final painter = TextPainter(
+    text: TextSpan(text: text, style: style),
+    textDirection: textDirection,
+    maxLines: 1,
+  )..layout();
+  final entries = <_GlyphPosition>[];
+  var offset = 0;
+  var index = 0;
+
+  for (final rune in text.runes) {
+    final glyph = String.fromCharCode(rune);
+    final start = offset;
+    offset += glyph.length;
+    if (glyph.trim().isEmpty) {
+      index++;
+      continue;
+    }
+    final boxes = painter.getBoxesForSelection(
+      TextSelection(baseOffset: start, extentOffset: offset),
+    );
+    final left = boxes.isEmpty
+        ? math.min(
+            painter
+                .getOffsetForCaret(TextPosition(offset: start), Rect.zero)
+                .dx,
+            painter
+                .getOffsetForCaret(TextPosition(offset: offset), Rect.zero)
+                .dx,
+          )
+        : boxes.fold<double>(
+            double.infinity,
+            (value, box) => math.min(value, math.min(box.left, box.right)),
+          );
+    entries.add(_GlyphPosition(glyph, left, index));
+    index++;
+  }
+
+  entries.sort(_compareGlyphPositions);
+  return [for (final entry in entries) entry.text];
+}
+
+int _compareGlyphPositions(_GlyphPosition a, _GlyphPosition b) {
+  final byLeft = a.left.compareTo(b.left);
+  if (byLeft != 0) {
+    return byLeft;
+  }
+  return a.sourceOrder.compareTo(b.sourceOrder);
+}
+
+class _GlyphPosition {
+  const _GlyphPosition(this.text, this.left, this.sourceOrder);
+
+  final String text;
+  final double left;
+  final int sourceOrder;
 }


### PR DESCRIPTION
## Summary
- Add visual-order glyph layout for RTL and mixed-bidi labels, with RTL visual diff aligned from the inline end.
- Keep rolling animation on the shared Row path without horizontal correction/Positioned glyphs.
- Add mixed-bidi recipe coverage and simplify example panel/recipe presentation.

## Test Plan
- flutter test
- flutter test (from example/)
- MCP analyze_files: No errors
- dart pub publish --dry-run