### PR TITLE
[codex] Trim pub archive maintenance

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -3,10 +3,17 @@
 .flutter-plugins-dependencies
 .agents/
 .idea/
+assets/
 build/
 coverage/
 docs/
+example/android/
+example/ios/
+example/linux/
+example/macos/
 example/output/
+example/web/reel-text-icon-source.png
+example/windows/
 pubspec.lock
 *-audit.log
 web-home-redesign-*.png

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Flutter. Each grapheme cluster gets its own measured slot, changed glyphs slide
 vertically, optional color flashes fade back to the inherited text color, and
 imperative `flash()` calls stay safe under rapid button taps.
 
-![reel_text showcase](assets/reel_text_hero_light_720p_60fps_full_cycle.webp)
+![reel_text showcase](https://raw.githubusercontent.com/KickNext/reel_text/main/assets/reel_text_hero_light_720p_60fps_full_cycle.webp)
 
 [Try the live demo](https://kicknext.github.io/reel_text/)
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -300,10 +300,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -560,10 +560,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/reel_text_alignment.dart
+++ b/lib/src/reel_text_alignment.dart
@@ -33,14 +33,12 @@ Alignment _alignmentForTextAlign(TextAlign align, TextDirection direction) {
     TextAlign.left => Alignment.centerLeft,
     TextAlign.right => Alignment.centerRight,
     TextAlign.center => Alignment.center,
-    TextAlign.end =>
-      direction == TextDirection.rtl
-          ? Alignment.centerLeft
-          : Alignment.centerRight,
-    TextAlign.start || TextAlign.justify =>
-      direction == TextDirection.rtl
-          ? Alignment.centerRight
-          : Alignment.centerLeft,
+    TextAlign.end => direction == TextDirection.rtl
+        ? Alignment.centerLeft
+        : Alignment.centerRight,
+    TextAlign.start || TextAlign.justify => direction == TextDirection.rtl
+        ? Alignment.centerRight
+        : Alignment.centerLeft,
   };
 }
 

--- a/lib/src/reel_text_api.dart
+++ b/lib/src/reel_text_api.dart
@@ -90,9 +90,8 @@ class ReelTextOptions {
       curve: curve ?? this.curve,
       bounce: bounce ?? this.bounce,
       color: clearColor ? color : color ?? this.color,
-      colorBuilder: clearColor
-          ? colorBuilder
-          : colorBuilder ?? this.colorBuilder,
+      colorBuilder:
+          clearColor ? colorBuilder : colorBuilder ?? this.colorBuilder,
       colorFade: colorFade ?? this.colorFade,
       skipUnchanged: skipUnchanged ?? this.skipUnchanged,
       interrupt: interrupt ?? this.interrupt,
@@ -146,8 +145,8 @@ class ReelTextOptions {
 typedef ReelWaitingFrameBuilder = String Function(String text, int tick);
 
 /// Builds per-value options for [ReelText.sequence].
-typedef ReelTextSequenceOptionsBuilder =
-    ReelTextOptions Function(int index, String value);
+typedef ReelTextSequenceOptionsBuilder = ReelTextOptions Function(
+    int index, String value);
 
 enum _ReelWaitingKind { ellipsis, wave, frames, builder, scramble }
 
@@ -163,15 +162,15 @@ class ReelWaiting {
   /// When [step] is omitted, the cadence is derived from the roll duration so
   /// every dot lands on a steady, metronome-like beat.
   const ReelWaiting.ellipsis({this.dots = 3, this.dot = '.', this.step})
-    : assert(dots > 0),
-      _kind = _ReelWaitingKind.ellipsis,
-      rest = Duration.zero,
-      frames = const <String>[],
-      frameBuilder = null,
-      alphabet = '',
-      changedGlyphs = 0,
-      protectedPrefix = 0,
-      holdEvery = 0;
+      : assert(dots > 0),
+        _kind = _ReelWaitingKind.ellipsis,
+        rest = Duration.zero,
+        frames = const <String>[],
+        frameBuilder = null,
+        alphabet = '',
+        changedGlyphs = 0,
+        protectedPrefix = 0,
+        holdEvery = 0;
 
   /// The whole label stays readable and periodically "breathes": a single
   /// stagger wave of self-rolls sweeps across the glyphs, then the label
@@ -180,42 +179,42 @@ class ReelWaiting {
   /// Without explicit options the wave uses a calm, non-springy curve and
   /// almost no tilt so the loop reads as a ripple instead of a glitch.
   const ReelWaiting.wave({this.rest = const Duration(milliseconds: 1300)})
-    : _kind = _ReelWaitingKind.wave,
-      dots = 0,
-      dot = '',
-      step = null,
-      frames = const <String>[],
-      frameBuilder = null,
-      alphabet = '',
-      changedGlyphs = 0,
-      protectedPrefix = 0,
-      holdEvery = 0;
+      : _kind = _ReelWaitingKind.wave,
+        dots = 0,
+        dot = '',
+        step = null,
+        frames = const <String>[],
+        frameBuilder = null,
+        alphabet = '',
+        changedGlyphs = 0,
+        protectedPrefix = 0,
+        holdEvery = 0;
 
   /// Cycles through explicit [frames] every [step].
   const ReelWaiting.frames(this.frames, {this.step})
-    : _kind = _ReelWaitingKind.frames,
-      dots = 0,
-      dot = '',
-      rest = Duration.zero,
-      frameBuilder = null,
-      alphabet = '',
-      changedGlyphs = 0,
-      protectedPrefix = 0,
-      holdEvery = 0;
+      : _kind = _ReelWaitingKind.frames,
+        dots = 0,
+        dot = '',
+        rest = Duration.zero,
+        frameBuilder = null,
+        alphabet = '',
+        changedGlyphs = 0,
+        protectedPrefix = 0,
+        holdEvery = 0;
 
   /// Generates each frame with [frameBuilder] every [step].
   const ReelWaiting.builder(
     ReelWaitingFrameBuilder this.frameBuilder, {
     this.step,
-  }) : _kind = _ReelWaitingKind.builder,
-       dots = 0,
-       dot = '',
-       rest = Duration.zero,
-       frames = const <String>[],
-       alphabet = '',
-       changedGlyphs = 0,
-       protectedPrefix = 0,
-       holdEvery = 0;
+  })  : _kind = _ReelWaitingKind.builder,
+        dots = 0,
+        dot = '',
+        rest = Duration.zero,
+        frames = const <String>[],
+        alphabet = '',
+        changedGlyphs = 0,
+        protectedPrefix = 0,
+        holdEvery = 0;
 
   /// Scrambles a small suffix of the readable label between held frames.
   ///
@@ -228,16 +227,16 @@ class ReelWaiting {
     this.protectedPrefix = 0,
     this.holdEvery = 4,
     this.step,
-  }) : assert(alphabet.length > 0),
-       assert(changedGlyphs > 0),
-       assert(protectedPrefix >= 0),
-       assert(holdEvery > 0),
-       _kind = _ReelWaitingKind.scramble,
-       dots = 0,
-       dot = '',
-       rest = Duration.zero,
-       frames = const <String>[],
-       frameBuilder = null;
+  })  : assert(alphabet.length > 0),
+        assert(changedGlyphs > 0),
+        assert(protectedPrefix >= 0),
+        assert(holdEvery > 0),
+        _kind = _ReelWaitingKind.scramble,
+        dots = 0,
+        dot = '',
+        rest = Duration.zero,
+        frames = const <String>[],
+        frameBuilder = null;
 
   final _ReelWaitingKind _kind;
 

--- a/lib/src/reel_text_controller.dart
+++ b/lib/src/reel_text_controller.dart
@@ -69,14 +69,13 @@ class ReelTextController extends ChangeNotifier {
     final sequence = frames.isEmpty
         ? <String>[text]
         : frames.first == text
-        ? List<String>.of(frames)
-        : <String>[text, ...frames];
+            ? List<String>.of(frames)
+            : <String>[text, ...frames];
     final progressOptions = (options ?? const ReelTextOptions()).copyWith(
       interrupt: false,
       skipUnchanged: !animateUnchanged,
     );
-    final tickInterval =
-        interval ??
+    final tickInterval = interval ??
         Duration(
           milliseconds: (progressOptions.duration.inMilliseconds * 0.55)
               .round()
@@ -147,8 +146,7 @@ class ReelTextController extends ChangeNotifier {
       case _ReelWaitingKind.wave:
         final base = options ?? _waveWaitingDefaults;
         final glyphCount = math.max(1, text.characters.length);
-        final sweepMs =
-            (glyphCount - 1) * base.stagger.inMilliseconds +
+        final sweepMs = (glyphCount - 1) * base.stagger.inMilliseconds +
             base.exitOffset.inMilliseconds +
             (base.duration.inMilliseconds * (1 + base.bounce * 0.45)).round() +
             (base.color != null || base.colorBuilder != null

--- a/lib/src/reel_text_editing.dart
+++ b/lib/src/reel_text_editing.dart
@@ -1,13 +1,12 @@
 part of 'reel_text.dart';
 
 /// Builds the resting text span for [ReelTextEditingController].
-typedef ReelTextEditingSpanBuilder =
-    TextSpan Function(
-      BuildContext context,
-      String text,
-      TextStyle style,
-      bool withComposing,
-    );
+typedef ReelTextEditingSpanBuilder = TextSpan Function(
+  BuildContext context,
+  String text,
+  TextStyle style,
+  bool withComposing,
+);
 
 /// A text replacement that [ReelTextEditingController] can animate inline.
 class ReelTextEditReplacement {

--- a/lib/src/reel_text_selection.dart
+++ b/lib/src/reel_text_selection.dart
@@ -48,7 +48,7 @@ class _ReelTextSelection extends StatelessWidget {
               selectionRegistrar: registrar,
               selectionColor:
                   DefaultSelectionStyle.of(context).selectionColor ??
-                  DefaultSelectionStyle.defaultColor,
+                      DefaultSelectionStyle.defaultColor,
             ),
           ),
         ),


### PR DESCRIPTION
## Summary

- Keep the README showcase image available through the GitHub raw URL instead of packaging the local asset into the pub archive.
- Exclude heavy README/example platform artifacts from the published package archive.
- Run Dart formatter and refresh the example lockfile for currently resolvable transitive updates.

## Impact

This is maintenance-only and does not change the runtime API. The pub dry-run archive drops from about 8 MB to 632 KB.

## Validation

- `dart format --output=none --set-exit-if-changed lib test example/lib example/test`
- `flutter analyze`
- `(cd example && flutter analyze)`
- `flutter test`
- `(cd example && flutter test)`
- `dart pub publish --dry-run`