### PR TITLE
[codex] Anchor pubignore asset exclusion

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -3,7 +3,7 @@
 .flutter-plugins-dependencies
 .agents/
 .idea/
-assets/
+/assets/reel_text_hero_light_720p_60fps_full_cycle.webp
 build/
 coverage/
 docs/


### PR DESCRIPTION
## Summary

- Replace the broad `.pubignore` `assets/` pattern with an explicit root hero asset path.
- Keep `example/assets/icons/github.svg` and `example/assets/icons/pubdev.svg` in the published archive so the packaged example can load its declared assets.

## Validation

- `dart format --output=none --set-exit-if-changed lib test example/lib example/test`
- `flutter analyze`
- `(cd example && flutter analyze)`
- `flutter test`
- `(cd example && flutter test)`
- `dart pub publish --dry-run` confirms the example SVG icons are included and the package has 0 warnings.