### PR TITLE
Document reel_text skill install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ imperative `flash()` calls stay safe under rapid button taps.
 flutter pub add reel_text
 ```
 
+Or add the dependency manually if you keep `pubspec.yaml` organized by hand:
+
+```yaml
+dependencies:
+  reel_text: ^0.1.6
+```
+
+Then run:
+
+```bash
+flutter pub get
+```
+
 The package supports Dart 3.2.0 and Flutter 3.16.0 and newer. The included
 showcase app tracks current stable Flutter because it uses modern demo-only UI
 APIs.
@@ -49,6 +62,14 @@ Install with the Agent Skills CLI:
 ```bash
 npx skills add KickNext/reel_text --skill reel-text
 ```
+
+Update an installed skill after this repository changes:
+
+```bash
+npx skills update reel-text --project
+```
+
+Use `--global` instead of `--project` if you installed the skill globally.
 
 Or install the
 [`skills/reel-text`](https://github.com/KickNext/reel_text/tree/main/skills/reel-text)
@@ -383,32 +404,4 @@ Run the included example:
 ```bash
 cd example
 flutter run
-```
-
-The example app is a showcase, not the package compatibility floor. It targets
-current stable Flutter separately from the library's Dart 3.2.0 and Flutter
-3.16.0 minimum.
-
-The example has three tabs:
-
-- **Home**: a self-running, choreographed presentation of the core motion
-  patterns, package metadata, install flow, counters, async labels, and inline
-  correction moments.
-- **Recipes**: live previews with copy-ready code for common integrations,
-  including RTL and mixed-bidi labels.
-- **Editor**: a motion workbench with a target input, direction/color/timing
-  controls, and a `ReelText.controller` preview.
-
-Build the web demo with:
-
-```bash
-cd example
-flutter build web
-```
-
-For the public GitHub Pages path, build with:
-
-```bash
-cd example
-flutter build web --base-href "/reel_text/"
 ```

--- a/skills/reel-text/SKILL.md
+++ b/skills/reel-text/SKILL.md
@@ -28,6 +28,7 @@ For code changes, report:
 
 - The text transition being animated.
 - The API chosen and why.
+- How the dependency was added or confirmed.
 - The layout constraint that prevents size jumps.
 - The lifecycle owner for any controller.
 - The verification command run.
@@ -40,6 +41,13 @@ For an app that does not already depend on the package:
 flutter pub add reel_text
 ```
 
+If `pubspec.yaml` is carefully grouped, commented, sorted, or otherwise hand-structured, preserve that structure instead of blindly running a command that may rewrite it. Add only the dependency line under `dependencies`, then run `flutter pub get`:
+
+```yaml
+dependencies:
+  reel_text: ^0.1.6
+```
+
 Then import:
 
 ```dart
@@ -47,6 +55,16 @@ import 'package:reel_text/reel_text.dart';
 ```
 
 Do not add the dependency just because the task mentions animation. First find a good candidate transition.
+
+## Source Lookup
+
+Before guessing APIs, inspect the package source available to the project:
+
+- If the project already ran `flutter pub get`, read `.dart_tool/package_config.json` and use the `reel_text` `rootUri`/`packageUri` to find `lib/`.
+- If package config is unavailable, check `${PUB_CACHE:-$HOME/.pub-cache}/hosted/pub.dev/reel_text-<version>/lib/`.
+- If working inside this repository, use the local `lib/` source.
+
+Use cached source as the API reference when docs and installed version may differ.
 
 ## Reject Plainly
 
@@ -131,12 +149,15 @@ await label.runWhile(
 - Use `Directionality` or `textDirection` when the label is outside an already directional subtree.
 - Preload async fonts before the first `ReelText` frame when the app relies on dynamically loaded fonts.
 - Validate `ReelTextEditReplacement` ranges; they must be in bounds and non-overlapping.
+- Preserve existing `pubspec.yaml` comments, grouping, ordering, and constraints when adding `reel_text`; do not normalize unrelated dependencies.
 
 ## Red Flags
 
 - Replacing many unrelated `Text` widgets in one pass.
 - Creating any `ReelTextController` inside `build`.
 - Adding `reel_text` to a project before identifying a qualifying transition.
+- Rewriting a carefully structured `pubspec.yaml` just to add one dependency.
+- Inventing API calls without checking local source or the pub cache when the package is installed.
 - Animating body copy, long errors, legal/help text, or static navigation labels.
 - Putting a rolling label in a button without a stable slot width.
 - Reimplementing waiting timers when `runWhile()` or `startWaiting()` matches the lifecycle.


### PR DESCRIPTION
## Summary
- document manual `pubspec.yaml` dependency installation and skill update commands
- teach the reel_text skill to preserve structured pubspec files
- add source lookup guidance for installed package cache and `.dart_tool/package_config.json`
- keep the README example section compact by removing duplicated demo-build details

## Verification
- python3 /Users/kicknext/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/kicknext/Pets/reel_text/skills/reel-text
- npx --yes skills add . --list
- npx --yes skills use . --skill reel-text | rg -n 'How the dependency|pubspec.yaml|Source Lookup|package_config|pub-cache|Rewriting a carefully structured'
- npx --yes skills add KickNext/reel_text --skill reel-text; npx --yes skills update reel-text --project -y in a temporary directory
- flutter analyze
- flutter test
- flutter pub publish --dry-run
