### PR TITLE
Avoid hardcoded install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,9 @@ imperative `flash()` calls stay safe under rapid button taps.
 flutter pub add reel_text
 ```
 
-Or add the dependency manually if you keep `pubspec.yaml` organized by hand:
-
-```yaml
-dependencies:
-  reel_text: ^0.1.6
-```
+If you keep `pubspec.yaml` organized by hand, add `reel_text` under
+`dependencies` using the current version constraint from
+[pub.dev](https://pub.dev/packages/reel_text/install).
 
 Then run:
 

--- a/skills/reel-text/SKILL.md
+++ b/skills/reel-text/SKILL.md
@@ -41,12 +41,7 @@ For an app that does not already depend on the package:
 flutter pub add reel_text
 ```
 
-If `pubspec.yaml` is carefully grouped, commented, sorted, or otherwise hand-structured, preserve that structure instead of blindly running a command that may rewrite it. Add only the dependency line under `dependencies`, then run `flutter pub get`:
-
-```yaml
-dependencies:
-  reel_text: ^0.1.6
-```
+If `pubspec.yaml` is carefully grouped, commented, sorted, or otherwise hand-structured, preserve that structure instead of blindly running a command that may rewrite it. Add `reel_text` under `dependencies` using the current version constraint from pub.dev, then run `flutter pub get`. Do not copy a hardcoded version from this skill.
 
 Then import:
 


### PR DESCRIPTION
## Summary
- remove the hardcoded `reel_text` install constraint from README
- point manual `pubspec.yaml` edits to the current pub.dev install constraint
- update the agent skill so AI agents do not copy stale package versions

## Verification
- rg -n "reel_text: \\^|0\\.1\\.6" README.md skills/reel-text/SKILL.md || true
- python3 /Users/kicknext/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/kicknext/Pets/reel_text/skills/reel-text
- npx --yes skills use . --skill reel-text | rg -n 'current version constraint|hardcoded version|pub.dev|pubspec.yaml'
- npx --yes skills add . --list
- flutter pub publish --dry-run
