### PR TITLE
Simplify root install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,6 @@ imperative `flash()` calls stay safe under rapid button taps.
 flutter pub add reel_text
 ```
 
-If you keep `pubspec.yaml` organized by hand, add `reel_text` under
-`dependencies` using the current version constraint from
-[pub.dev](https://pub.dev/packages/reel_text/install).
-
-Then run:
-
-```bash
-flutter pub get
-```
-
 The package supports Dart 3.2.0 and Flutter 3.16.0 and newer.
 
 Then import it:


### PR DESCRIPTION
## Summary
- remove the conditional manual `pubspec.yaml` paragraph from the root install section
- remove the extra `flutter pub get` step that belonged only to that manual path
- keep the install flow focused on `flutter pub add reel_text` and the import

## Verification
- rg -n "If you keep|current version constraint|pub.dev/packages/reel_text/install|flutter pub get" README.md || true
- git diff --check
- flutter pub publish --dry-run
