### PR TITLE
[codex] optimize reel text rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.0
+
+- Reworked plain rolling text slots to paint through cached render objects,
+  reducing per-frame widget rebuild work for dense `ReelText` scenes.
+- Added a full-screen performance stress screen to the example app with theme
+  support and adjustable tile density.
+- Fixed RTL rolling slot alignment while animated slot widths change.
+- Added intrinsic/dry layout support for painted rolling slots and disposed
+  transient/cached `TextPainter` resources used by the optimized paint path.
+- No public API changes.
+
 ## 0.3.0
 
 - Added `WidgetSpan` support to `ReelText.rich`: inline widgets now stay in the

--- a/example/README.md
+++ b/example/README.md
@@ -17,6 +17,8 @@ It demonstrates:
 - Numeric counters, status pills, rotating labels, and rich text.
 - A motion workbench with target editing, direction/color/timing controls, and
   a `ReelText.controller` preview.
+- A full-screen Performance page with a checkerboard of looping `ReelText`
+  swaps for visual stress testing.
 
 Run it with:
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,11 +11,15 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'editor_page.dart';
 import 'home_page.dart';
+import 'performance_page.dart';
 import 'recipes_page.dart';
 import 'studio.dart';
 
 const double _kShellMaxWidth = 1280;
 const String _kThemePreferenceKey = 'reel_text_example_brightness';
+const int _kInitialPageFromEnvironment = int.fromEnvironment(
+  'REEL_TEXT_EXAMPLE_INITIAL_PAGE',
+);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -72,6 +76,7 @@ class ReelTextExampleApp extends StatefulWidget {
     super.key,
     this.useGoogleFonts = true,
     this.autoPlayHero = true,
+    this.initialPage = _kInitialPageFromEnvironment,
     this.initialBrightnessOverride,
     this.themePreferenceStore = const ThemePreferenceStore(),
   });
@@ -82,6 +87,7 @@ class ReelTextExampleApp extends StatefulWidget {
   /// Set to false in widget tests so the hero stage does not auto-advance.
   final bool autoPlayHero;
 
+  final int initialPage;
   final Brightness? initialBrightnessOverride;
   final ThemePreferenceStore themePreferenceStore;
 
@@ -185,6 +191,7 @@ class _ReelTextExampleAppState extends State<ReelTextExampleApp>
       home: StudioShell(
         autoPlayHero: widget.autoPlayHero,
         loadLiveMetadata: widget.useGoogleFonts,
+        initialPage: widget.initialPage,
         brightness: brightness,
         onBrightnessChanged: _setBrightness,
       ),
@@ -197,12 +204,14 @@ class StudioShell extends StatefulWidget {
     super.key,
     this.autoPlayHero = true,
     this.loadLiveMetadata = true,
+    this.initialPage = 0,
     required this.brightness,
     required this.onBrightnessChanged,
   });
 
   final bool autoPlayHero;
   final bool loadLiveMetadata;
+  final int initialPage;
   final Brightness brightness;
   final ValueChanged<Brightness> onBrightnessChanged;
 
@@ -211,7 +220,13 @@ class StudioShell extends StatefulWidget {
 }
 
 class _StudioShellState extends State<StudioShell> {
-  int _page = 0;
+  late int _page;
+
+  @override
+  void initState() {
+    super.initState();
+    _page = widget.initialPage.clamp(0, 3).toInt();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -222,6 +237,10 @@ class _StudioShellState extends State<StudioShell> {
       ),
       TickerMode(enabled: _page == 1, child: const RecipesPage()),
       TickerMode(enabled: _page == 2, child: const EditorPage()),
+      TickerMode(
+        enabled: _page == 3,
+        child: PerformancePage(active: _page == 3),
+      ),
     ];
     return Scaffold(
       body: SafeArea(
@@ -274,7 +293,7 @@ class _TopBarState extends State<_TopBar> {
   late Future<_PackageStats> _stats;
   Timer? _statsRefreshTimer;
 
-  static const _pageNames = ['HOME', 'RECIPES', 'EDITOR'];
+  static const _pageNames = ['HOME', 'RECIPES', 'EDITOR', 'PERF'];
   static const _statsRefreshInterval = Duration(seconds: 125);
 
   static final _pubDevUri = Uri.parse('https://pub.dev/packages/reel_text');
@@ -566,60 +585,75 @@ class _PageTabs extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final visualTabs = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (var i = 0; i < pageNames.length; i++)
-          _PageTabVisual(
-            label: pageNames[i],
-            selected: i == selected,
-            compact: compact,
-          ),
-      ],
-    );
-    final hitTargets = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (var i = 0; i < pageNames.length; i++)
-          _PageTabHitTarget(
-            key: ValueKey('page_tab_${pageNames[i].toLowerCase()}'),
-            label: pageNames[i],
-            selected: i == selected,
-            compact: compact,
-            onTap: () => onPageChanged(i),
-          ),
-      ],
-    );
+    final media = MediaQuery.of(context);
+    return MediaQuery(
+      data: media.copyWith(textScaler: TextScaler.noScaling),
+      child: Builder(
+        builder: (context) {
+          final visualTabs = Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < pageNames.length; i++)
+                _PageTabVisual(
+                  label: pageNames[i],
+                  selected: i == selected,
+                  compact: compact,
+                ),
+            ],
+          );
+          final hitTargets = Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < pageNames.length; i++)
+                _PageTabHitTarget(
+                  key: ValueKey('page_tab_${_pageTabKey(pageNames[i])}'),
+                  label: pageNames[i],
+                  selected: i == selected,
+                  compact: compact,
+                  onTap: () => onPageChanged(i),
+                ),
+            ],
+          );
 
-    return SizedBox(
-      key: const ValueKey('page_tabs_frame'),
-      height: 48,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          ExcludeSemantics(
-            child: Center(
-              child: DecoratedBox(
-                key: const ValueKey('page_tabs_rail'),
-                decoration: BoxDecoration(
-                  color: Studio.inset.withValues(alpha: 0.88),
-                  borderRadius: BorderRadius.circular(999),
-                  border: Border.all(
-                    color: Studio.borderBright.withValues(alpha: 0.42),
+          return SizedBox(
+            key: const ValueKey('page_tabs_frame'),
+            height: 48,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                ExcludeSemantics(
+                  child: Center(
+                    child: DecoratedBox(
+                      key: const ValueKey('page_tabs_rail'),
+                      decoration: BoxDecoration(
+                        color: Studio.inset.withValues(alpha: 0.88),
+                        borderRadius: BorderRadius.circular(999),
+                        border: Border.all(
+                          color: Studio.borderBright.withValues(alpha: 0.42),
+                        ),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.all(3),
+                        child: visualTabs,
+                      ),
+                    ),
                   ),
                 ),
-                child: Padding(
-                  padding: const EdgeInsets.all(3),
-                  child: visualTabs,
-                ),
-              ),
+                Center(child: hitTargets),
+              ],
             ),
-          ),
-          Center(child: hitTargets),
-        ],
+          );
+        },
       ),
     );
   }
+}
+
+String _pageTabKey(String label) {
+  return switch (label) {
+    'PERF' => 'performance',
+    _ => label.toLowerCase(),
+  };
 }
 
 class _PageTabVisual extends StatelessWidget {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -221,6 +221,7 @@ class StudioShell extends StatefulWidget {
 
 class _StudioShellState extends State<StudioShell> {
   late int _page;
+  var _performanceTileTarget = 4.0;
 
   @override
   void initState() {
@@ -239,7 +240,12 @@ class _StudioShellState extends State<StudioShell> {
       TickerMode(enabled: _page == 2, child: const EditorPage()),
       TickerMode(
         enabled: _page == 3,
-        child: PerformancePage(active: _page == 3),
+        child: PerformancePage(
+          active: _page == 3,
+          tileTarget: _performanceTileTarget,
+          onTileTargetChanged: (value) =>
+              setState(() => _performanceTileTarget = value),
+        ),
       ),
     ];
     return Scaffold(

--- a/example/lib/performance_page.dart
+++ b/example/lib/performance_page.dart
@@ -1,0 +1,384 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:reel_text/reel_text.dart';
+
+import 'studio.dart';
+
+const _kPerformanceCueHold = Duration(milliseconds: 1450);
+const _kPerformanceRollDuration = Duration(milliseconds: 560);
+const _kPerformanceRollStagger = Duration(milliseconds: 38);
+const _kPerformanceRollBounce = 0.12;
+const _kPerformanceProfileLog = bool.fromEnvironment(
+  'REEL_TEXT_EXAMPLE_PROFILE_LOG',
+);
+
+class PerformancePage extends StatefulWidget {
+  const PerformancePage({super.key, required this.active});
+
+  final bool active;
+
+  @override
+  State<PerformancePage> createState() => _PerformancePageState();
+}
+
+class _PerformancePageState extends State<PerformancePage> {
+  Timer? _timer;
+  Timer? _profileLogTimer;
+  final _profileTimings = <FrameTiming>[];
+  var _profileTimingsAttached = false;
+  var _phase = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.active) {
+      _start();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant PerformancePage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.active == widget.active) {
+      return;
+    }
+    if (widget.active) {
+      _start();
+    } else {
+      _timer?.cancel();
+      _timer = null;
+      _stopProfileLog();
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _stopProfileLog();
+    super.dispose();
+  }
+
+  void _start() {
+    _timer?.cancel();
+    _timer = Timer.periodic(_kPerformanceCueHold, (_) {
+      if (mounted && widget.active) {
+        setState(() => _phase = !_phase);
+      }
+    });
+    _startProfileLog();
+  }
+
+  void _startProfileLog() {
+    if (!_kPerformanceProfileLog || _profileTimingsAttached) {
+      return;
+    }
+    _profileTimingsAttached = true;
+    SchedulerBinding.instance.addTimingsCallback(_handleProfileTimings);
+    _profileLogTimer = Timer.periodic(
+      const Duration(seconds: 5),
+      (_) => _logProfileTimings(),
+    );
+  }
+
+  void _stopProfileLog() {
+    if (!_profileTimingsAttached) {
+      return;
+    }
+    _logProfileTimings();
+    _profileLogTimer?.cancel();
+    _profileLogTimer = null;
+    SchedulerBinding.instance.removeTimingsCallback(_handleProfileTimings);
+    _profileTimingsAttached = false;
+    _profileTimings.clear();
+  }
+
+  void _handleProfileTimings(List<FrameTiming> timings) {
+    if (widget.active) {
+      _profileTimings.addAll(timings);
+    }
+  }
+
+  void _logProfileTimings() {
+    final timings = List<FrameTiming>.of(_profileTimings);
+    _profileTimings.clear();
+    if (timings.isEmpty) {
+      return;
+    }
+
+    double average(Iterable<Duration> durations) {
+      final micros = durations.map((duration) => duration.inMicroseconds);
+      return micros.reduce((a, b) => a + b) / timings.length / 1000;
+    }
+
+    final buildAverage = average(timings.map((timing) => timing.buildDuration));
+    final rasterAverage = average(
+      timings.map((timing) => timing.rasterDuration),
+    );
+    final totalAverage = average(timings.map((timing) => timing.totalSpan));
+    final worstTotal =
+        timings.fold<int>(
+          0,
+          (maxMicros, timing) =>
+              math.max(maxMicros, timing.totalSpan.inMicroseconds).toInt(),
+        ) /
+        1000;
+    final overBudget = timings
+        .where((timing) => timing.totalSpan > const Duration(milliseconds: 16))
+        .length;
+
+    debugPrint(
+      'PerformancePage frames=${timings.length} '
+      'build_avg=${buildAverage.toStringAsFixed(2)}ms '
+      'raster_avg=${rasterAverage.toStringAsFixed(2)}ms '
+      'total_avg=${totalAverage.toStringAsFixed(2)}ms '
+      'worst_total=${worstTotal.toStringAsFixed(2)}ms '
+      'over_16ms=$overBudget',
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: SizedBox.expand(
+        key: const ValueKey('performance_scene'),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final width = constraints.maxWidth;
+            final height = constraints.maxHeight;
+            final compact = width < 720;
+            final columns = math.max(5, (width / (compact ? 82 : 126)).ceil());
+            final rows = math.max(8, (height / (compact ? 52 : 64)).ceil());
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                const _PerformanceBackdrop(),
+                _PerformanceCheckerboard(
+                  phase: _phase,
+                  rows: rows,
+                  columns: columns,
+                  compact: compact,
+                ),
+                const _PerformanceEdgeFade(),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _PerformanceBackdrop extends StatelessWidget {
+  const _PerformanceBackdrop();
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      key: const ValueKey('performance_backdrop'),
+      decoration: BoxDecoration(color: _performanceBackground),
+    );
+  }
+}
+
+Color get _performanceBackground =>
+    Studio.isLight ? const Color(0xfff7fbff) : const Color(0xff030711);
+
+Color get _performanceText =>
+    Studio.isLight ? const Color(0xff15243a) : Colors.white;
+
+class _PerformanceCheckerboard extends StatelessWidget {
+  const _PerformanceCheckerboard({
+    required this.phase,
+    required this.rows,
+    required this.columns,
+    required this.compact,
+  });
+
+  final bool phase;
+  final int rows;
+  final int columns;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const ValueKey('performance_checkerboard'),
+      children: [
+        for (var row = 0; row < rows; row++)
+          Expanded(
+            child: Row(
+              children: [
+                for (var column = 0; column < columns; column++)
+                  Expanded(
+                    child: _PerformanceTile(
+                      index: row * columns + column,
+                      reversed: (row + column).isOdd,
+                      phase: phase,
+                      compact: compact,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _PerformanceTile extends StatelessWidget {
+  const _PerformanceTile({
+    required this.index,
+    required this.reversed,
+    required this.phase,
+    required this.compact,
+  });
+
+  final int index;
+  final bool reversed;
+  final bool phase;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final showReel = reversed ? phase : !phase;
+    final blue = Studio.sky;
+    final label = showReel ? 'reel' : 'text';
+    final labelColor = _performanceText;
+
+    return ClipRect(
+      key: ValueKey('performance_tile_clip_$index'),
+      child: Center(
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              SizedBox.shrink(
+                key: ValueKey(
+                  showReel
+                      ? 'performance_reel_tile_$index'
+                      : 'performance_text_tile_$index',
+                ),
+              ),
+              ReelText(
+                label,
+                key: ValueKey('performance_tile_$index'),
+                options: ReelTextOptions(
+                  direction: showReel
+                      ? ReelTextDirection.up
+                      : ReelTextDirection.down,
+                  duration: _kPerformanceRollDuration,
+                  stagger: _kPerformanceRollStagger,
+                  bounce: _kPerformanceRollBounce,
+                  colorBuilder: showReel ? chromatic(from: index * 19) : null,
+                  color: showReel ? null : blue,
+                ),
+                style: Studio.display(
+                  size: compact ? 28 : 38,
+                  height: 1,
+                  color: labelColor,
+                  weight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PerformanceEdgeFade extends StatelessWidget {
+  const _PerformanceEdgeFade();
+
+  @override
+  Widget build(BuildContext context) {
+    final fade = _performanceBackground;
+    final screen = MediaQuery.sizeOf(context);
+    final edge = math.min(240.0, math.max(148.0, screen.shortestSide * 0.36));
+    return IgnorePointer(
+      key: const ValueKey('performance_edge_fade'),
+      child: Stack(
+        children: [
+          Positioned(
+            left: 0,
+            right: 0,
+            top: 0,
+            height: edge,
+            child: _EdgeFadeBand(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              color: fade,
+            ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: edge,
+            child: _EdgeFadeBand(
+              begin: Alignment.bottomCenter,
+              end: Alignment.topCenter,
+              color: fade,
+            ),
+          ),
+          Positioned(
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: edge,
+            child: _EdgeFadeBand(
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+              color: fade,
+            ),
+          ),
+          Positioned(
+            right: 0,
+            top: 0,
+            bottom: 0,
+            width: edge,
+            child: _EdgeFadeBand(
+              begin: Alignment.centerRight,
+              end: Alignment.centerLeft,
+              color: fade,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EdgeFadeBand extends StatelessWidget {
+  const _EdgeFadeBand({
+    required this.begin,
+    required this.end,
+    required this.color,
+  });
+
+  final Alignment begin;
+  final Alignment end;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: begin,
+          end: end,
+          colors: [
+            color,
+            color.withValues(alpha: 0.82),
+            color.withValues(alpha: 0),
+          ],
+          stops: const [0, 0.34, 1],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/performance_page.dart
+++ b/example/lib/performance_page.dart
@@ -11,14 +11,29 @@ const _kPerformanceCueHold = Duration(milliseconds: 1450);
 const _kPerformanceRollDuration = Duration(milliseconds: 560);
 const _kPerformanceRollStagger = Duration(milliseconds: 38);
 const _kPerformanceRollBounce = 0.12;
+const _kPerformanceMinTileCount = 4.0;
+const _kPerformanceMaxDensity = 3.0;
+const _kPerformanceTileGap = 10.0;
+const _kPerformanceCompactTileGap = 8.0;
+const _kPerformanceStressDescription =
+    'This is a stress test, not a normal usage example. Each ReelText '
+    'in the grid is independent and animates separately, so high density '
+    'can visibly slow down.';
 const _kPerformanceProfileLog = bool.fromEnvironment(
   'REEL_TEXT_EXAMPLE_PROFILE_LOG',
 );
 
 class PerformancePage extends StatefulWidget {
-  const PerformancePage({super.key, required this.active});
+  const PerformancePage({
+    super.key,
+    required this.active,
+    required this.tileTarget,
+    required this.onTileTargetChanged,
+  });
 
   final bool active;
+  final double tileTarget;
+  final ValueChanged<double> onTileTargetChanged;
 
   @override
   State<PerformancePage> createState() => _PerformancePageState();
@@ -149,22 +164,195 @@ class _PerformancePageState extends State<PerformancePage> {
             final width = constraints.maxWidth;
             final height = constraints.maxHeight;
             final compact = width < 720;
-            final columns = math.max(5, (width / (compact ? 82 : 126)).ceil());
-            final rows = math.max(8, (height / (compact ? 52 : 64)).ceil());
+            final baseTileWidth = compact ? 82.0 : 126.0;
+            final baseTileHeight = compact ? 52.0 : 64.0;
+            final maxColumns = math.max(
+              5,
+              (width / (baseTileWidth / _kPerformanceMaxDensity)).ceil(),
+            );
+            final maxRows = math.max(
+              8,
+              (height / (baseTileHeight / _kPerformanceMaxDensity)).ceil(),
+            );
+            final maxTileCount = math
+                .max(_kPerformanceMinTileCount.toInt(), maxRows * maxColumns)
+                .toDouble();
+            final tileTarget = widget.tileTarget
+                .clamp(_kPerformanceMinTileCount, maxTileCount)
+                .toDouble();
+            final grid = _PerformanceGridShape.fromTarget(
+              target: tileTarget.round(),
+              maxRows: maxRows,
+              maxColumns: maxColumns,
+              width: width,
+              height: height,
+            );
+            final controlWidth = math.min(360.0, math.max(0.0, width - 40.0));
+            final controlLeft = math.max(0.0, (width - controlWidth) / 2);
+            final controlBottom = MediaQuery.paddingOf(context).bottom + 22;
             return Stack(
               fit: StackFit.expand,
               children: [
                 const _PerformanceBackdrop(),
                 _PerformanceCheckerboard(
                   phase: _phase,
-                  rows: rows,
-                  columns: columns,
+                  rows: grid.rows,
+                  columns: grid.columns,
                   compact: compact,
                 ),
                 const _PerformanceEdgeFade(),
+                Positioned(
+                  left: controlLeft,
+                  bottom: controlBottom,
+                  width: controlWidth,
+                  child: _PerformanceDensityControl(
+                    tileTarget: tileTarget,
+                    maxTileCount: maxTileCount,
+                    tileCount: grid.tileCount,
+                    onChanged: widget.onTileTargetChanged,
+                  ),
+                ),
               ],
             );
           },
+        ),
+      ),
+    );
+  }
+}
+
+class _PerformanceGridShape {
+  const _PerformanceGridShape({required this.rows, required this.columns});
+
+  final int rows;
+  final int columns;
+
+  int get tileCount => rows * columns;
+
+  static _PerformanceGridShape fromTarget({
+    required int target,
+    required int maxRows,
+    required int maxColumns,
+    required double width,
+    required double height,
+  }) {
+    final maxTiles = maxRows * maxColumns;
+    final requested = target.clamp(_kPerformanceMinTileCount.toInt(), maxTiles);
+    if (requested >= maxTiles) {
+      return _PerformanceGridShape(rows: maxRows, columns: maxColumns);
+    }
+    if (requested <= _kPerformanceMinTileCount) {
+      return const _PerformanceGridShape(rows: 2, columns: 2);
+    }
+
+    final aspect = height <= 0 ? 1.0 : width / height;
+    var columns = math.sqrt(requested * aspect).ceil().clamp(2, maxColumns);
+    var rows = (requested / columns).ceil().clamp(2, maxRows);
+
+    if (rows == maxRows && rows * columns < requested) {
+      columns = (requested / rows).ceil().clamp(2, maxColumns);
+    }
+
+    while (columns > 2 && rows * (columns - 1) >= requested) {
+      columns--;
+    }
+    while (rows > 2 && (rows - 1) * columns >= requested) {
+      rows--;
+    }
+
+    return _PerformanceGridShape(rows: rows, columns: columns);
+  }
+}
+
+class _PerformanceDensityControl extends StatelessWidget {
+  const _PerformanceDensityControl({
+    required this.tileTarget,
+    required this.maxTileCount,
+    required this.tileCount,
+    required this.onChanged,
+  });
+
+  final double tileTarget;
+  final double maxTileCount;
+  final int tileCount;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final background = Studio.isLight
+        ? Colors.white.withValues(alpha: 0.82)
+        : const Color(0xff07101f).withValues(alpha: 0.72);
+    final border = Studio.isLight
+        ? const Color(0xffc7d7ef).withValues(alpha: 0.68)
+        : Colors.white.withValues(alpha: 0.12);
+    final countLabel = '$tileCount tiles';
+
+    return SizedBox(
+      key: const ValueKey('performance_density_layer'),
+      child: DecoratedBox(
+        key: const ValueKey('performance_density_control'),
+        decoration: BoxDecoration(
+          color: background,
+          border: Border.all(color: border),
+          borderRadius: BorderRadius.circular(8),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.16),
+              blurRadius: 18,
+              offset: const Offset(0, 10),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsetsDirectional.fromSTEB(14, 10, 12, 10),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                _kPerformanceStressDescription,
+                key: const ValueKey('performance_stress_description'),
+                style: Studio.body(
+                  size: 11.5,
+                  height: 1.32,
+                  color: _performanceText.withValues(alpha: 0.82),
+                  weight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Row(
+                children: [
+                  SizedBox(
+                    width: 86,
+                    child: Text(
+                      countLabel,
+                      key: const ValueKey('performance_density_count'),
+                      maxLines: 1,
+                      overflow: TextOverflow.fade,
+                      softWrap: false,
+                      style: Studio.mono(
+                        size: 12,
+                        color: _performanceText,
+                        weight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Slider(
+                      key: const ValueKey('performance_density_slider'),
+                      min: _kPerformanceMinTileCount,
+                      max: maxTileCount,
+                      value: tileTarget,
+                      label: countLabel,
+                      semanticFormatterCallback: (value) =>
+                          '${value.round()} independent ReelText widgets',
+                      onChanged: onChanged,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -247,43 +435,47 @@ class _PerformanceTile extends StatelessWidget {
     final blue = Studio.sky;
     final label = showReel ? 'reel' : 'text';
     final labelColor = _performanceText;
+    final gap = compact ? _kPerformanceCompactTileGap : _kPerformanceTileGap;
 
-    return ClipRect(
-      key: ValueKey('performance_tile_clip_$index'),
-      child: Center(
-        child: FittedBox(
-          fit: BoxFit.scaleDown,
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              SizedBox.shrink(
-                key: ValueKey(
-                  showReel
-                      ? 'performance_reel_tile_$index'
-                      : 'performance_text_tile_$index',
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: gap / 2, vertical: gap / 2),
+      child: ClipRect(
+        key: ValueKey('performance_tile_clip_$index'),
+        child: Center(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                SizedBox.shrink(
+                  key: ValueKey(
+                    showReel
+                        ? 'performance_reel_tile_$index'
+                        : 'performance_text_tile_$index',
+                  ),
                 ),
-              ),
-              ReelText(
-                label,
-                key: ValueKey('performance_tile_$index'),
-                options: ReelTextOptions(
-                  direction: showReel
-                      ? ReelTextDirection.up
-                      : ReelTextDirection.down,
-                  duration: _kPerformanceRollDuration,
-                  stagger: _kPerformanceRollStagger,
-                  bounce: _kPerformanceRollBounce,
-                  colorBuilder: showReel ? chromatic(from: index * 19) : null,
-                  color: showReel ? null : blue,
+                ReelText(
+                  label,
+                  key: ValueKey('performance_tile_$index'),
+                  options: ReelTextOptions(
+                    direction: showReel
+                        ? ReelTextDirection.up
+                        : ReelTextDirection.down,
+                    duration: _kPerformanceRollDuration,
+                    stagger: _kPerformanceRollStagger,
+                    bounce: _kPerformanceRollBounce,
+                    colorBuilder: showReel ? chromatic(from: index * 19) : null,
+                    color: showReel ? null : blue,
+                  ),
+                  style: Studio.display(
+                    size: compact ? 28 : 38,
+                    height: 1,
+                    color: labelColor,
+                    weight: FontWeight.w800,
+                  ),
                 ),
-                style: Studio.display(
-                  size: compact ? 28 : 38,
-                  height: 1,
-                  color: labelColor,
-                  weight: FontWeight.w800,
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -253,6 +253,121 @@ void main() {
     );
   });
 
+  testWidgets('performance page density slider increases stress tile count', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.byKey(const ValueKey('page_tab_performance')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final initialTiles = _performanceTileClipCount();
+    expect(initialTiles, 4);
+    expect(
+      find.text(
+        'This is a stress test, not a normal usage example. Each ReelText '
+        'in the grid is independent and animates separately, so high density '
+        'can visibly slow down.',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('performance_density_slider')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('performance_chroma_switch')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('performance_color_switch')),
+      findsNothing,
+    );
+    expect(find.text('4 tiles'), findsOneWidget);
+    final densityLayer = find.byKey(
+      const ValueKey('performance_density_layer'),
+    );
+    expect(densityLayer, findsOneWidget);
+    expect(tester.getSize(densityLayer).width, lessThan(400));
+    expect(tester.getSize(densityLayer).height, lessThan(170));
+
+    expect(
+      tester
+          .widget<ReelText>(find.byKey(const ValueKey('performance_tile_0')))
+          .options
+          .colorBuilder,
+      isNotNull,
+    );
+    expect(
+      tester
+          .widget<ReelText>(find.byKey(const ValueKey('performance_tile_1')))
+          .options
+          .color,
+      Studio.sky,
+    );
+
+    final slider = tester.widget<Slider>(
+      find.byKey(const ValueKey('performance_density_slider')),
+    );
+    final maxTiles = _performanceMaxTileCount(
+      tester.getSize(find.byKey(const ValueKey('performance_scene'))),
+    );
+    expect(slider.max, maxTiles);
+
+    slider.onChanged!(maxTiles);
+    await tester.pump();
+
+    expect(_performanceTileClipCount(), maxTiles);
+    final firstTile = tester.getRect(
+      find.byKey(const ValueKey('performance_tile_clip_0')),
+    );
+    final secondTile = tester.getRect(
+      find.byKey(const ValueKey('performance_tile_clip_1')),
+    );
+    expect(secondTile.left - firstTile.right, greaterThanOrEqualTo(6));
+
+    final stressedTiles = _performanceTileClipCount();
+    await tester.tap(find.byKey(const ValueKey('theme_toggle_button')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      tester
+          .widget<Slider>(
+            find.byKey(const ValueKey('performance_density_slider')),
+          )
+          .value,
+      maxTiles,
+    );
+    expect(
+      find.byKey(const ValueKey('performance_chroma_switch')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('performance_color_switch')),
+      findsNothing,
+    );
+    expect(
+      tester
+          .widget<ReelText>(find.byKey(const ValueKey('performance_tile_0')))
+          .options
+          .colorBuilder,
+      isNotNull,
+    );
+    expect(
+      tester
+          .widget<ReelText>(find.byKey(const ValueKey('performance_tile_1')))
+          .options
+          .color,
+      Studio.sky,
+    );
+    expect(_performanceTileClipCount(), stressedTiles);
+  });
+
   testWidgets('app bar theme toggle switches the studio palette', (
     tester,
   ) async {
@@ -1348,6 +1463,27 @@ Finder _semanticButtonWithLabel(String label) {
         widget.properties.label == label,
     description: 'semantic button with label "$label"',
   );
+}
+
+int _performanceTileClipCount() {
+  return find
+      .byWidgetPredicate(
+        (widget) =>
+            widget.key is ValueKey<String> &&
+            (widget.key! as ValueKey<String>).value.startsWith(
+              'performance_tile_clip_',
+            ),
+        description: 'performance tile clips',
+      )
+      .evaluate()
+      .length;
+}
+
+double _performanceMaxTileCount(Size size) {
+  final compact = size.width < 720;
+  final columns = (size.width / ((compact ? 82 : 126) / 3)).ceil();
+  final rows = (size.height / ((compact ? 52 : 64) / 3)).ceil();
+  return (columns * rows).toDouble();
 }
 
 Color? _panelColor(WidgetTester tester, String key) {

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -90,6 +90,7 @@ void main() {
     expect(find.byKey(const ValueKey('page_tab_home')), findsOneWidget);
     expect(find.byKey(const ValueKey('page_tab_recipes')), findsOneWidget);
     expect(find.byKey(const ValueKey('page_tab_editor')), findsOneWidget);
+    expect(find.byKey(const ValueKey('page_tab_performance')), findsOneWidget);
     expect(
       find.byKey(const ValueKey('app_bar_metadata_links')),
       findsOneWidget,
@@ -120,6 +121,136 @@ void main() {
       find.byKey(const ValueKey('hero_brand_word')),
     );
     expect(heroLine.controller!.value, '1,024');
+  });
+
+  testWidgets('performance page shows a full-screen reel stress scene', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byKey(const ValueKey('page_tab_performance')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('page_tab_performance')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final scene = find.byKey(const ValueKey('performance_scene'));
+    final body = find.byKey(const ValueKey('shell_body_frame'));
+
+    expect(scene, findsOneWidget);
+    expect(tester.getSize(scene), tester.getSize(body));
+    expect(
+      _decoratedBoxColor(tester, 'performance_backdrop'),
+      const Color(0xff030711),
+    );
+    expect(
+      find.byKey(const ValueKey('performance_checkerboard')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('performance_edge_fade')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('performance_reel_tile_0')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('performance_text_tile_1')),
+      findsOneWidget,
+    );
+    final firstClip = find.byKey(const ValueKey('performance_tile_clip_0'));
+    expect(firstClip, findsOneWidget);
+    expect(find.text('reel -> text'), findsNothing);
+    expect(find.text('text -> reel'), findsNothing);
+
+    final reelTile = tester.widget<ReelText>(
+      find.byKey(const ValueKey('performance_tile_0')),
+    );
+    expect(reelTile.style?.color, Studio.white);
+    expect(reelTile.options.duration, const Duration(milliseconds: 560));
+    expect(reelTile.options.stagger, const Duration(milliseconds: 38));
+    expect(reelTile.options.exitOffset, const Duration(milliseconds: 50));
+    expect(reelTile.options.bounce, 0.12);
+    expect(reelTile.options.color, isNull);
+    expect(reelTile.options.colorBuilder, isNotNull);
+    expect(tester.getSize(firstClip).width, greaterThan(0));
+    expect(tester.getSize(firstClip).height, greaterThan(0));
+    expect(
+      tester.getSize(firstClip).width,
+      lessThan(tester.getSize(scene).width),
+    );
+    expect(
+      tester.getSize(firstClip).height,
+      lessThan(tester.getSize(scene).height),
+    );
+
+    final textTile = tester.widget<ReelText>(
+      find.byKey(const ValueKey('performance_tile_1')),
+    );
+    expect(textTile.style?.color, Studio.white);
+    expect(textTile.options.color, Studio.sky);
+    expect(textTile.options.colorBuilder, isNull);
+
+    await tester.pump(const Duration(milliseconds: 1450));
+
+    expect(
+      find.descendant(
+        of: scene,
+        matching: find.byKey(const ValueKey('reel_text_rolling')),
+      ),
+      findsWidgets,
+    );
+  });
+
+  testWidgets('performance page follows dark and light theme palettes', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.byKey(const ValueKey('page_tab_performance')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      _decoratedBoxColor(tester, 'performance_backdrop'),
+      const Color(0xff030711),
+    );
+    expect(
+      tester
+          .widget<ReelText>(find.byKey(const ValueKey('performance_tile_0')))
+          .style
+          ?.color,
+      Studio.white,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('theme_toggle_button')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      _decoratedBoxColor(tester, 'performance_backdrop'),
+      const Color(0xfff7fbff),
+    );
+    expect(
+      tester
+          .widget<ReelText>(find.byKey(const ValueKey('performance_tile_0')))
+          .style
+          ?.color,
+      const Color(0xff15243a),
+    );
+    expect(
+      tester
+          .widget<ReelText>(find.byKey(const ValueKey('performance_tile_1')))
+          .options
+          .color,
+      Studio.sky,
+    );
   });
 
   testWidgets('app bar theme toggle switches the studio palette', (
@@ -265,6 +396,22 @@ void main() {
     await _expectAccessibilityGuidelines(tester);
   });
 
+  testWidgets('performance page meets Flutter accessibility guidelines', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.byKey(const ValueKey('page_tab_performance')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await _expectAccessibilityGuidelines(tester);
+  });
+
   testWidgets('recipes page meets Flutter accessibility guidelines', (
     tester,
   ) async {
@@ -327,6 +474,23 @@ void main() {
     await _expectAccessibilityGuidelines(tester);
   });
 
+  testWidgets(
+    'mobile performance page meets Flutter accessibility guidelines',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(390, 844));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.byKey(const ValueKey('page_tab_performance')));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      await _expectAccessibilityGuidelines(tester);
+    },
+  );
+
   testWidgets('primary pages tolerate 200 percent text scaling', (
     tester,
   ) async {
@@ -349,6 +513,10 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('page_tab_editor')));
     await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.byKey(const ValueKey('page_tab_performance')));
+    await tester.pump(const Duration(milliseconds: 300));
     expect(tester.takeException(), isNull);
   });
 
@@ -602,7 +770,7 @@ void main() {
     expect(actions.right, closeTo(topFrame.right - 14, 0.01));
     expect(title.right, lessThan(actions.left));
     expect(tabsFrame.width, topFrame.width - 28);
-    expect(tabsRail.width, lessThan(tabsFrame.width * 0.72));
+    expect(tabsRail.width, lessThan(tabsFrame.width));
     expect(tabsRail.center.dx, closeTo(tabsFrame.center.dx, 0.01));
   });
 
@@ -1187,6 +1355,11 @@ Color? _panelColor(WidgetTester tester, String key) {
   final decoratedBox = tester.widget<DecoratedBox>(
     find.descendant(of: panel, matching: find.byType(DecoratedBox)).first,
   );
+  return (decoratedBox.decoration as BoxDecoration).color;
+}
+
+Color? _decoratedBoxColor(WidgetTester tester, String key) {
+  final decoratedBox = tester.widget<DecoratedBox>(find.byKey(ValueKey(key)));
   return (decoratedBox.decoration as BoxDecoration).color;
 }
 

--- a/lib/src/reel_text_alignment.dart
+++ b/lib/src/reel_text_alignment.dart
@@ -13,17 +13,11 @@ class _ReelTextAlignment extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (!constraints.hasTightWidth) {
-          return child;
-        }
-
-        return Align(
-          alignment: _alignmentForTextAlign(textAlign, textDirection),
-          child: child,
-        );
-      },
+    return Align(
+      alignment: _alignmentForTextAlign(textAlign, textDirection),
+      widthFactor: 1,
+      heightFactor: 1,
+      child: child,
     );
   }
 }

--- a/lib/src/reel_text_roll_state.dart
+++ b/lib/src/reel_text_roll_state.dart
@@ -54,6 +54,62 @@ class _MeasuredReelTextFrame {
   final _MeasuredReelTextRun run;
 }
 
+class _SettledReelTextCache {
+  const _SettledReelTextCache({
+    required this.key,
+    required this.measured,
+    required this.child,
+  });
+
+  final _SettledReelTextCacheKey key;
+  final _MeasuredReelTextFrame measured;
+  final Widget child;
+}
+
+class _SettledReelTextCacheKey {
+  const _SettledReelTextCacheKey({
+    required this.frame,
+    required this.style,
+    required this.textDirection,
+    required this.locale,
+    required this.strutStyle,
+    required this.textScaler,
+    required this.widgetSpanMetricsVersion,
+  });
+
+  final _ReelTextFrame frame;
+  final TextStyle style;
+  final TextDirection textDirection;
+  final Locale? locale;
+  final StrutStyle? strutStyle;
+  final TextScaler textScaler;
+  final int widgetSpanMetricsVersion;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _SettledReelTextCacheKey &&
+        _sameFrameTarget(frame, other.frame) &&
+        style == other.style &&
+        textDirection == other.textDirection &&
+        locale == other.locale &&
+        strutStyle == other.strutStyle &&
+        textScaler == other.textScaler &&
+        widgetSpanMetricsVersion == other.widgetSpanMetricsVersion;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        frame.text,
+        identityHashCode(frame.richText),
+        style,
+        textDirection,
+        locale,
+        strutStyle,
+        textScaler,
+        widgetSpanMetricsVersion,
+      );
+}
+
 class _ActiveRoll {
   const _ActiveRoll({
     required this.from,

--- a/lib/src/reel_text_runs.dart
+++ b/lib/src/reel_text_runs.dart
@@ -3,20 +3,15 @@ part of 'reel_text.dart';
 class _SettledReelText extends StatelessWidget {
   const _SettledReelText({
     super.key,
-    required this.content,
+    required this.run,
     required this.layout,
   });
 
-  final _ReelTextContent content;
+  final _MeasuredReelTextRun run;
   final _ReelTextLayoutContext layout;
 
   @override
   Widget build(BuildContext context) {
-    final run = _MeasuredReelTextRun.of(
-      context: context,
-      content: content,
-      layout: layout,
-    );
     final runMetrics = run.metrics;
     final tokenRow = Row(
       key: const ValueKey('reel_text_settled_glyphs'),
@@ -158,33 +153,35 @@ class _RollingReelText extends StatelessWidget {
     final anchorShrinkingRight =
         _alignsToRight(textAlign, layout.textDirection) &&
             toRun.width < fromRun.width;
+    final rollingRow = Row(
+      key: const ValueKey('reel_text_rolling'),
+      mainAxisSize: MainAxisSize.min,
+      textDirection: TextDirection.ltr,
+      children: [
+        for (final slot in plan.slots)
+          _RollingTokenSlot(
+            slot: slot,
+            fromRun: fromRun,
+            toRun: toRun,
+            animation: animation,
+            totalDurationMs: plan.totalDuration.inMilliseconds,
+            layout: layout,
+          ),
+      ],
+    );
     return AnimatedBuilder(
       animation: animation,
-      builder: (context, _) {
+      child: rollingRow,
+      builder: (context, child) {
         final progressMs = animation.value * plan.totalDuration.inMilliseconds;
         final width = _rollingWidth(progressMs);
-        final rollingRow = Row(
-          key: const ValueKey('reel_text_rolling'),
-          mainAxisSize: MainAxisSize.min,
-          textDirection: TextDirection.ltr,
-          children: [
-            for (final slot in plan.slots)
-              _RollingTokenSlot(
-                slot: slot,
-                fromRun: fromRun,
-                toRun: toRun,
-                progressMs: progressMs,
-                layout: layout,
-              ),
-          ],
-        );
         if (hasWidgetSlots) {
           return _SettledTokenRowViewport(
             height: height,
             alignment: anchorShrinkingRight
                 ? layout.inlineStartAlignment
                 : _alignmentForTextAlign(textAlign, layout.textDirection),
-            child: rollingRow,
+            child: child!,
           );
         }
         final viewportWidth = anchorShrinkingRight ? toRun.width : width;
@@ -199,7 +196,7 @@ class _RollingReelText extends StatelessWidget {
             maxWidth: double.infinity,
             minHeight: height,
             maxHeight: double.infinity,
-            child: rollingRow,
+            child: child!,
           ),
         );
       },

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -356,6 +356,11 @@ class _RenderRollingTextSlotFace extends RenderBox {
 
   int get debugPreparedFaceLayoutCount => _preparedFaceLayoutCount;
 
+  double get debugPreparedToFaceDx =>
+      _toFace == null ? double.nan : _faceDxFor(_toFace!.width);
+
+  double get debugCurrentToFaceDx => _faceDxFor(_data.metrics.toWidth);
+
   double get debugHorizontalBleed =>
       _horizontalTextTokenBleed(_data.metrics.height);
 
@@ -519,7 +524,6 @@ class _RenderRollingTextSlotFace extends RenderBox {
       width: width,
       height: height,
       paintWidth: paintWidth,
-      faceDx: _faceDxFor(width),
       paintDx: _paintDxFor(width, paintWidth),
     );
   }
@@ -535,8 +539,10 @@ class _RenderRollingTextSlotFace extends RenderBox {
       return;
     }
 
+    final faceDx = _faceDxFor(face.width);
+
     canvas.save();
-    canvas.translate(face.faceDx + face.width / 2, dy + face.height / 2);
+    canvas.translate(faceDx + face.width / 2, dy + face.height / 2);
     if (angle != 0) {
       canvas.rotate(angle);
     }
@@ -645,7 +651,6 @@ class _PreparedTextFace {
     required this.width,
     required this.height,
     required this.paintWidth,
-    required this.faceDx,
     required this.paintDx,
   });
 
@@ -653,7 +658,6 @@ class _PreparedTextFace {
   final double width;
   final double height;
   final double paintWidth;
-  final double faceDx;
   final double paintDx;
 }
 

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -53,14 +53,16 @@ class _RollingTokenSlot extends StatelessWidget {
     required this.slot,
     required this.fromRun,
     required this.toRun,
-    required this.progressMs,
+    required this.animation,
+    required this.totalDurationMs,
     required this.layout,
   });
 
   final _SlotPlan slot;
   final _MeasuredReelTextRun fromRun;
   final _MeasuredReelTextRun toRun;
-  final double progressMs;
+  final Animation<double> animation;
+  final int totalDurationMs;
   final _ReelTextLayoutContext layout;
 
   @override
@@ -83,7 +85,13 @@ class _RollingTokenSlot extends StatelessWidget {
     if (data.hasWidgetEndpoint) {
       return _buildAtomicSwap(data);
     }
-    return _buildRollingText(context, data);
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) {
+        final progressMs = animation.value * totalDurationMs;
+        return _buildRollingText(context, data, progressMs);
+      },
+    );
   }
 
   Widget _buildUnchanged(_TokenSlotRenderData data) {
@@ -148,7 +156,11 @@ class _RollingTokenSlot extends StatelessWidget {
     );
   }
 
-  Widget _buildRollingText(BuildContext context, _TokenSlotRenderData data) {
+  Widget _buildRollingText(
+    BuildContext context,
+    _TokenSlotRenderData data,
+    double progressMs,
+  ) {
     final width = ui.lerpDouble(
       data.metrics.fromWidth,
       data.metrics.toWidth,

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -1,7 +1,5 @@
 part of 'reel_text.dart';
 
-const _kRollingTextColorFaceSteps = 8;
-
 class _SettledTokenSlot extends StatelessWidget {
   const _SettledTokenSlot(
     this.token, {
@@ -278,7 +276,6 @@ class _RenderRollingTextSlotFace extends RenderBox {
   Color _defaultTextColor;
   _PreparedTextFace? _fromFace;
   _PreparedTextFace? _toFace;
-  final _toColorFaces = <int, _PreparedTextFace>{};
   var _preparedFaceLayoutCount = 0;
 
   _TokenSlotRenderData get data => _data;
@@ -484,10 +481,11 @@ class _RenderRollingTextSlotFace extends RenderBox {
           opacity: 1,
         );
       } else {
-        final face = _preparedToColorFace(incomingColor);
-        _paintPreparedTokenFace(
+        _paintTokenFace(
           canvas,
-          face: face,
+          text: _data.toText,
+          style: _data.effectiveToStyle.copyWith(color: incomingColor),
+          width: _data.metrics.toWidth,
           dy: dy,
           angle: angle,
           opacity: 1,
@@ -523,20 +521,6 @@ class _RenderRollingTextSlotFace extends RenderBox {
       paintWidth: paintWidth,
       faceDx: _faceDxFor(width),
       paintDx: _paintDxFor(width, paintWidth),
-    );
-  }
-
-  _PreparedTextFace _preparedToColorFace(Color color) {
-    final key = _colorCacheKey(color);
-    return _toColorFaces.putIfAbsent(
-      key,
-      () => _prepareTokenFace(
-        text: _data.toText,
-        style: _data.effectiveToStyle.copyWith(
-          color: _quantizedColor(color),
-        ),
-        width: _data.metrics.toWidth,
-      ),
     );
   }
 
@@ -579,10 +563,65 @@ class _RenderRollingTextSlotFace extends RenderBox {
     canvas.restore();
   }
 
+  void _paintTokenFace(
+    Canvas canvas, {
+    required String text,
+    required TextStyle style,
+    required double width,
+    required double dy,
+    required double angle,
+    required double opacity,
+  }) {
+    if (text.isEmpty || opacity <= 0.001) {
+      return;
+    }
+
+    final height = _data.metrics.height;
+    final horizontalBleed = _horizontalTextTokenBleed(height);
+    final paintWidth = width + horizontalBleed;
+    final faceDx = _faceDxFor(width);
+    final paintDx = _paintDxFor(width, paintWidth);
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: _layout.textDirection,
+      textAlign: TextAlign.start,
+      textScaler: _textScaler,
+      locale: _layout.locale,
+      strutStyle: _layout.strutStyle,
+      maxLines: 1,
+    )..layout(minWidth: paintWidth, maxWidth: paintWidth);
+
+    canvas.save();
+    canvas.translate(faceDx + width / 2, dy + height / 2);
+    if (angle != 0) {
+      canvas.rotate(angle);
+    }
+    canvas.translate(-width / 2, -height / 2);
+
+    if (opacity < 0.999) {
+      canvas.saveLayer(
+        Rect.fromLTWH(paintDx, 0, paintWidth, height),
+        Paint()
+          ..color = Color.fromARGB(
+            (opacity.clamp(0.0, 1.0) * 255).round(),
+            255,
+            255,
+            255,
+          ),
+      );
+    }
+
+    painter.paint(canvas, Offset(paintDx, 0));
+
+    if (opacity < 0.999) {
+      canvas.restore();
+    }
+    canvas.restore();
+  }
+
   void _clearPreparedFaces() {
     _fromFace = null;
     _toFace = null;
-    _toColorFaces.clear();
   }
 
   double _faceDxFor(double width) {
@@ -598,20 +637,6 @@ class _RenderRollingTextSlotFace extends RenderBox {
         ? width - paintWidth
         : 0.0;
   }
-}
-
-int _colorCacheKey(Color color) => _quantizedColor(color).toARGB32();
-
-Color _quantizedColor(Color color) {
-  double quantize(double value) =>
-      (value * _kRollingTextColorFaceSteps).round() /
-      _kRollingTextColorFaceSteps;
-  return Color.from(
-    alpha: quantize(color.a),
-    red: quantize(color.r),
-    green: quantize(color.g),
-    blue: quantize(color.b),
-  );
 }
 
 class _PreparedTextFace {

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -274,6 +274,9 @@ class _RenderRollingTextSlotFace extends RenderBox {
   _ReelTextLayoutContext _layout;
   TextScaler _textScaler;
   Color _defaultTextColor;
+  _PreparedTextFace? _fromFace;
+  _PreparedTextFace? _toFace;
+  var _preparedFaceLayoutCount = 0;
 
   _TokenSlotRenderData get data => _data;
 
@@ -282,6 +285,7 @@ class _RenderRollingTextSlotFace extends RenderBox {
       return;
     }
     _data = value;
+    _clearPreparedFaces();
     markNeedsLayout();
     markNeedsPaint();
   }
@@ -321,6 +325,7 @@ class _RenderRollingTextSlotFace extends RenderBox {
       return;
     }
     _layout = value;
+    _clearPreparedFaces();
     markNeedsPaint();
   }
 
@@ -331,6 +336,7 @@ class _RenderRollingTextSlotFace extends RenderBox {
       return;
     }
     _textScaler = value;
+    _clearPreparedFaces();
     markNeedsPaint();
   }
 
@@ -341,11 +347,14 @@ class _RenderRollingTextSlotFace extends RenderBox {
       return;
     }
     _defaultTextColor = value;
+    _clearPreparedFaces();
     markNeedsPaint();
   }
 
   double get debugIncomingY =>
       _data.slot.inY(_progressMs, _data.travelDistance);
+
+  int get debugPreparedFaceLayoutCount => _preparedFaceLayoutCount;
 
   double get debugHorizontalBleed =>
       _horizontalTextTokenBleed(_data.metrics.height);
@@ -437,11 +446,13 @@ class _RenderRollingTextSlotFace extends RenderBox {
     canvas.translate(offset.dx, offset.dy);
 
     if (_data.fromEndpoint != null) {
-      _paintTokenFace(
+      _paintPreparedTokenFace(
         canvas,
-        text: _data.fromText,
-        style: _data.effectiveFromStyle,
-        width: _data.metrics.fromWidth,
+        face: _fromFace ??= _prepareTokenFace(
+          text: _data.fromText,
+          style: _data.effectiveFromStyle,
+          width: _data.metrics.fromWidth,
+        ),
         dy: _data.slot.outY(progressMs, _data.travelDistance),
         angle: -_data.slot.tiltRadians * _data.slot.outT(progressMs),
         opacity: _data.slot.outOpacity(progressMs),
@@ -455,17 +466,100 @@ class _RenderRollingTextSlotFace extends RenderBox {
               _defaultTextColor,
               _data.slot.colorT(progressMs),
             )!;
-      _paintTokenFace(
-        canvas,
-        text: _data.toText,
-        style: _data.effectiveToStyle.copyWith(color: incomingColor),
-        width: _data.metrics.toWidth,
-        dy: _data.slot.inY(progressMs, _data.travelDistance),
-        angle: _data.slot.tiltRadians * (1 - _data.slot.inT(progressMs)),
-        opacity: 1,
+      final angle = _data.slot.tiltRadians * (1 - _data.slot.inT(progressMs));
+      final dy = _data.slot.inY(progressMs, _data.travelDistance);
+      if (_data.slot.color == null) {
+        _paintPreparedTokenFace(
+          canvas,
+          face: _toFace ??= _prepareTokenFace(
+            text: _data.toText,
+            style: _data.effectiveToStyle.copyWith(color: incomingColor),
+            width: _data.metrics.toWidth,
+          ),
+          dy: dy,
+          angle: angle,
+          opacity: 1,
+        );
+      } else {
+        _paintTokenFace(
+          canvas,
+          text: _data.toText,
+          style: _data.effectiveToStyle.copyWith(color: incomingColor),
+          width: _data.metrics.toWidth,
+          dy: dy,
+          angle: angle,
+          opacity: 1,
+        );
+      }
+    }
+
+    canvas.restore();
+  }
+
+  _PreparedTextFace _prepareTokenFace({
+    required String text,
+    required TextStyle style,
+    required double width,
+  }) {
+    final height = _data.metrics.height;
+    final horizontalBleed = _horizontalTextTokenBleed(height);
+    final paintWidth = width + horizontalBleed;
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: _layout.textDirection,
+      textAlign: TextAlign.start,
+      textScaler: _textScaler,
+      locale: _layout.locale,
+      strutStyle: _layout.strutStyle,
+      maxLines: 1,
+    )..layout(minWidth: paintWidth, maxWidth: paintWidth);
+    _preparedFaceLayoutCount++;
+    return _PreparedTextFace(
+      painter: painter,
+      width: width,
+      height: height,
+      paintWidth: paintWidth,
+      faceDx: _faceDxFor(width),
+      paintDx: _paintDxFor(width, paintWidth),
+    );
+  }
+
+  void _paintPreparedTokenFace(
+    Canvas canvas, {
+    required _PreparedTextFace face,
+    required double dy,
+    required double angle,
+    required double opacity,
+  }) {
+    if (opacity <= 0.001) {
+      return;
+    }
+
+    canvas.save();
+    canvas.translate(face.faceDx + face.width / 2, dy + face.height / 2);
+    if (angle != 0) {
+      canvas.rotate(angle);
+    }
+    canvas.translate(-face.width / 2, -face.height / 2);
+
+    if (opacity < 0.999) {
+      canvas.saveLayer(
+        Rect.fromLTWH(face.paintDx, 0, face.paintWidth, face.height),
+        Paint()
+          ..color = Color.fromARGB(
+            (opacity.clamp(0.0, 1.0) * 255).round(),
+            255,
+            255,
+            255,
+          ),
       );
     }
 
+    face.painter.paint(canvas, Offset(face.paintDx, 0));
+
+    if (opacity < 0.999) {
+      canvas.restore();
+    }
     canvas.restore();
   }
 
@@ -525,6 +619,11 @@ class _RenderRollingTextSlotFace extends RenderBox {
     canvas.restore();
   }
 
+  void _clearPreparedFaces() {
+    _fromFace = null;
+    _toFace = null;
+  }
+
   double _faceDxFor(double width) {
     return _layout.inlineStartAlignment
         .alongOffset(
@@ -538,6 +637,24 @@ class _RenderRollingTextSlotFace extends RenderBox {
         ? width - paintWidth
         : 0.0;
   }
+}
+
+class _PreparedTextFace {
+  const _PreparedTextFace({
+    required this.painter,
+    required this.width,
+    required this.height,
+    required this.paintWidth,
+    required this.faceDx,
+    required this.paintDx,
+  });
+
+  final TextPainter painter;
+  final double width;
+  final double height;
+  final double paintWidth;
+  final double faceDx;
+  final double paintDx;
 }
 
 class _VerticalSlotClipper extends CustomClipper<Rect> {

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -1,5 +1,7 @@
 part of 'reel_text.dart';
 
+const _kRollingTextColorFaceSteps = 8;
+
 class _SettledTokenSlot extends StatelessWidget {
   const _SettledTokenSlot(
     this.token, {
@@ -276,6 +278,7 @@ class _RenderRollingTextSlotFace extends RenderBox {
   Color _defaultTextColor;
   _PreparedTextFace? _fromFace;
   _PreparedTextFace? _toFace;
+  final _toColorFaces = <int, _PreparedTextFace>{};
   var _preparedFaceLayoutCount = 0;
 
   _TokenSlotRenderData get data => _data;
@@ -481,11 +484,10 @@ class _RenderRollingTextSlotFace extends RenderBox {
           opacity: 1,
         );
       } else {
-        _paintTokenFace(
+        final face = _preparedToColorFace(incomingColor);
+        _paintPreparedTokenFace(
           canvas,
-          text: _data.toText,
-          style: _data.effectiveToStyle.copyWith(color: incomingColor),
-          width: _data.metrics.toWidth,
+          face: face,
           dy: dy,
           angle: angle,
           opacity: 1,
@@ -521,6 +523,20 @@ class _RenderRollingTextSlotFace extends RenderBox {
       paintWidth: paintWidth,
       faceDx: _faceDxFor(width),
       paintDx: _paintDxFor(width, paintWidth),
+    );
+  }
+
+  _PreparedTextFace _preparedToColorFace(Color color) {
+    final key = _colorCacheKey(color);
+    return _toColorFaces.putIfAbsent(
+      key,
+      () => _prepareTokenFace(
+        text: _data.toText,
+        style: _data.effectiveToStyle.copyWith(
+          color: _quantizedColor(color),
+        ),
+        width: _data.metrics.toWidth,
+      ),
     );
   }
 
@@ -563,65 +579,10 @@ class _RenderRollingTextSlotFace extends RenderBox {
     canvas.restore();
   }
 
-  void _paintTokenFace(
-    Canvas canvas, {
-    required String text,
-    required TextStyle style,
-    required double width,
-    required double dy,
-    required double angle,
-    required double opacity,
-  }) {
-    if (text.isEmpty || opacity <= 0.001) {
-      return;
-    }
-
-    final height = _data.metrics.height;
-    final horizontalBleed = _horizontalTextTokenBleed(height);
-    final paintWidth = width + horizontalBleed;
-    final faceDx = _faceDxFor(width);
-    final paintDx = _paintDxFor(width, paintWidth);
-    final painter = TextPainter(
-      text: TextSpan(text: text, style: style),
-      textDirection: _layout.textDirection,
-      textAlign: TextAlign.start,
-      textScaler: _textScaler,
-      locale: _layout.locale,
-      strutStyle: _layout.strutStyle,
-      maxLines: 1,
-    )..layout(minWidth: paintWidth, maxWidth: paintWidth);
-
-    canvas.save();
-    canvas.translate(faceDx + width / 2, dy + height / 2);
-    if (angle != 0) {
-      canvas.rotate(angle);
-    }
-    canvas.translate(-width / 2, -height / 2);
-
-    if (opacity < 0.999) {
-      canvas.saveLayer(
-        Rect.fromLTWH(paintDx, 0, paintWidth, height),
-        Paint()
-          ..color = Color.fromARGB(
-            (opacity.clamp(0.0, 1.0) * 255).round(),
-            255,
-            255,
-            255,
-          ),
-      );
-    }
-
-    painter.paint(canvas, Offset(paintDx, 0));
-
-    if (opacity < 0.999) {
-      canvas.restore();
-    }
-    canvas.restore();
-  }
-
   void _clearPreparedFaces() {
     _fromFace = null;
     _toFace = null;
+    _toColorFaces.clear();
   }
 
   double _faceDxFor(double width) {
@@ -637,6 +598,20 @@ class _RenderRollingTextSlotFace extends RenderBox {
         ? width - paintWidth
         : 0.0;
   }
+}
+
+int _colorCacheKey(Color color) => _quantizedColor(color).toARGB32();
+
+Color _quantizedColor(Color color) {
+  double quantize(double value) =>
+      (value * _kRollingTextColorFaceSteps).round() /
+      _kRollingTextColorFaceSteps;
+  return Color.from(
+    alpha: quantize(color.a),
+    red: quantize(color.r),
+    green: quantize(color.g),
+    blue: quantize(color.b),
+  );
 }
 
 class _PreparedTextFace {

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -85,13 +85,7 @@ class _RollingTokenSlot extends StatelessWidget {
     if (data.hasWidgetEndpoint) {
       return _buildAtomicSwap(data);
     }
-    return AnimatedBuilder(
-      animation: animation,
-      builder: (context, _) {
-        final progressMs = animation.value * totalDurationMs;
-        return _buildRollingText(context, data, progressMs);
-      },
-    );
+    return _buildPaintedRollingText(context, data);
   }
 
   Widget _buildUnchanged(_TokenSlotRenderData data) {
@@ -156,74 +150,26 @@ class _RollingTokenSlot extends StatelessWidget {
     );
   }
 
-  Widget _buildRollingText(
+  Widget _buildPaintedRollingText(
     BuildContext context,
     _TokenSlotRenderData data,
-    double progressMs,
   ) {
-    final width = ui.lerpDouble(
-      data.metrics.fromWidth,
-      data.metrics.toWidth,
-      slot.widthT(progressMs),
-    )!;
     final textColor = data.effectiveToStyle.color ??
         DefaultTextStyle.of(context).style.color ??
         Colors.black;
-    final incomingColor = slot.color == null
-        ? textColor
-        : Color.lerp(slot.color, textColor, slot.colorT(progressMs))!;
 
     return ClipRect(
       clipper: const _VerticalSlotClipper(),
       clipBehavior: Clip.hardEdge,
-      child: SizedBox(
-        width: width,
-        height: data.metrics.height,
-        child: Stack(
-          clipBehavior: Clip.none,
-          alignment: layout.inlineStartAlignment,
-          children: [
-            if (data.fromEndpoint != null)
-              Opacity(
-                opacity: slot.outOpacity(progressMs),
-                child: Transform.translate(
-                  offset: Offset(0, slot.outY(progressMs, data.travelDistance)),
-                  child: Transform.rotate(
-                    angle: -slot.tiltRadians * slot.outT(progressMs),
-                    child: _TextTokenFace(
-                      data.fromText,
-                      width: data.metrics.fromWidth,
-                      height: data.metrics.height,
-                      horizontalBleed: _horizontalTextTokenBleed(
-                        data.metrics.height,
-                      ),
-                      style: data.effectiveFromStyle,
-                      layout: layout,
-                    ),
-                  ),
-                ),
-              ),
-            if (data.toEndpoint != null)
-              Transform.translate(
-                offset: Offset(0, slot.inY(progressMs, data.travelDistance)),
-                child: Transform.rotate(
-                  angle: slot.tiltRadians * (1 - slot.inT(progressMs)),
-                  child: _TextTokenFace(
-                    data.toText,
-                    width: data.metrics.toWidth,
-                    height: data.metrics.height,
-                    horizontalBleed: _horizontalTextTokenBleed(
-                      data.metrics.height,
-                    ),
-                    style: data.effectiveToStyle.copyWith(
-                      color: incomingColor,
-                    ),
-                    layout: layout,
-                  ),
-                ),
-              ),
-          ],
-        ),
+      child: _RollingTextSlotFace(
+        key: const ValueKey('reel_text_rolling_text_slot'),
+        data: data,
+        animation: animation,
+        totalDurationMs: totalDurationMs,
+        layout: layout,
+        textScaler:
+            MediaQuery.maybeTextScalerOf(context) ?? TextScaler.noScaling,
+        defaultTextColor: textColor,
       ),
     );
   }
@@ -260,6 +206,338 @@ class _TokenSlotRenderData {
 
   double get travelDistance =>
       metrics.height + _verticalSlotBleed(metrics.height) * 2;
+}
+
+class _RollingTextSlotFace extends LeafRenderObjectWidget {
+  const _RollingTextSlotFace({
+    super.key,
+    required this.data,
+    required this.animation,
+    required this.totalDurationMs,
+    required this.layout,
+    required this.textScaler,
+    required this.defaultTextColor,
+  });
+
+  final _TokenSlotRenderData data;
+  final Animation<double> animation;
+  final int totalDurationMs;
+  final _ReelTextLayoutContext layout;
+  final TextScaler textScaler;
+  final Color defaultTextColor;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderRollingTextSlotFace(
+      data: data,
+      animation: animation,
+      totalDurationMs: totalDurationMs,
+      layout: layout,
+      textScaler: textScaler,
+      defaultTextColor: defaultTextColor,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderRollingTextSlotFace renderObject,
+  ) {
+    renderObject
+      ..data = data
+      ..animation = animation
+      ..totalDurationMs = totalDurationMs
+      ..layoutContext = layout
+      ..textScaler = textScaler
+      ..defaultTextColor = defaultTextColor;
+  }
+}
+
+class _RenderRollingTextSlotFace extends RenderBox {
+  _RenderRollingTextSlotFace({
+    required _TokenSlotRenderData data,
+    required Animation<double> animation,
+    required int totalDurationMs,
+    required _ReelTextLayoutContext layout,
+    required TextScaler textScaler,
+    required Color defaultTextColor,
+  })  : _data = data,
+        _animation = animation,
+        _totalDurationMs = totalDurationMs,
+        _layout = layout,
+        _textScaler = textScaler,
+        _defaultTextColor = defaultTextColor;
+
+  _TokenSlotRenderData _data;
+  Animation<double> _animation;
+  int _totalDurationMs;
+  _ReelTextLayoutContext _layout;
+  TextScaler _textScaler;
+  Color _defaultTextColor;
+
+  _TokenSlotRenderData get data => _data;
+
+  set data(_TokenSlotRenderData value) {
+    if (identical(_data, value)) {
+      return;
+    }
+    _data = value;
+    markNeedsLayout();
+    markNeedsPaint();
+  }
+
+  Animation<double> get animation => _animation;
+
+  set animation(Animation<double> value) {
+    if (identical(_animation, value)) {
+      return;
+    }
+    if (attached) {
+      _animation.removeListener(_handleAnimationTick);
+    }
+    _animation = value;
+    if (attached) {
+      _animation.addListener(_handleAnimationTick);
+    }
+    markNeedsLayout();
+    markNeedsPaint();
+  }
+
+  int get totalDurationMs => _totalDurationMs;
+
+  set totalDurationMs(int value) {
+    if (_totalDurationMs == value) {
+      return;
+    }
+    _totalDurationMs = value;
+    markNeedsLayout();
+    markNeedsPaint();
+  }
+
+  _ReelTextLayoutContext get layoutContext => _layout;
+
+  set layoutContext(_ReelTextLayoutContext value) {
+    if (identical(_layout, value)) {
+      return;
+    }
+    _layout = value;
+    markNeedsPaint();
+  }
+
+  TextScaler get textScaler => _textScaler;
+
+  set textScaler(TextScaler value) {
+    if (_textScaler == value) {
+      return;
+    }
+    _textScaler = value;
+    markNeedsPaint();
+  }
+
+  Color get defaultTextColor => _defaultTextColor;
+
+  set defaultTextColor(Color value) {
+    if (_defaultTextColor == value) {
+      return;
+    }
+    _defaultTextColor = value;
+    markNeedsPaint();
+  }
+
+  double get debugIncomingY =>
+      _data.slot.inY(_progressMs, _data.travelDistance);
+
+  double get debugHorizontalBleed =>
+      _horizontalTextTokenBleed(_data.metrics.height);
+
+  List<Map<String, Object>> get debugVisibleGlyphBounds {
+    final progressMs = _progressMs;
+    final entries = <Map<String, Object>>[];
+    if (_data.fromEndpoint != null) {
+      _addDebugGlyphBounds(
+        entries,
+        text: _data.fromText,
+        width: _data.metrics.fromWidth,
+        dy: _data.slot.outY(progressMs, _data.travelDistance),
+        opacity: _data.slot.outOpacity(progressMs),
+      );
+    }
+    if (_data.toEndpoint != null) {
+      _addDebugGlyphBounds(
+        entries,
+        text: _data.toText,
+        width: _data.metrics.toWidth,
+        dy: _data.slot.inY(progressMs, _data.travelDistance),
+        opacity: 1,
+      );
+    }
+    return entries;
+  }
+
+  void _addDebugGlyphBounds(
+    List<Map<String, Object>> entries, {
+    required String text,
+    required double width,
+    required double dy,
+    required double opacity,
+  }) {
+    if (text.isEmpty || opacity <= 0.01) {
+      return;
+    }
+    final height = _data.metrics.height;
+    final paintWidth = width + _horizontalTextTokenBleed(height);
+    entries.add({
+      'text': text,
+      'left': _faceDxFor(width) + _paintDxFor(width, paintWidth),
+      'top': dy,
+      'bottom': dy + height,
+    });
+  }
+
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    _animation.addListener(_handleAnimationTick);
+  }
+
+  @override
+  void detach() {
+    _animation.removeListener(_handleAnimationTick);
+    super.detach();
+  }
+
+  void _handleAnimationTick() {
+    markNeedsLayout();
+    markNeedsPaint();
+  }
+
+  double get _progressMs => _animation.value * _totalDurationMs;
+
+  double get _currentWidth {
+    return ui.lerpDouble(
+      _data.metrics.fromWidth,
+      _data.metrics.toWidth,
+      _data.slot.widthT(_progressMs),
+    )!;
+  }
+
+  @override
+  void performLayout() {
+    size = constraints.constrain(
+      Size(_currentWidth, _data.metrics.height),
+    );
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    final canvas = context.canvas;
+    final progressMs = _progressMs;
+
+    canvas.save();
+    canvas.translate(offset.dx, offset.dy);
+
+    if (_data.fromEndpoint != null) {
+      _paintTokenFace(
+        canvas,
+        text: _data.fromText,
+        style: _data.effectiveFromStyle,
+        width: _data.metrics.fromWidth,
+        dy: _data.slot.outY(progressMs, _data.travelDistance),
+        angle: -_data.slot.tiltRadians * _data.slot.outT(progressMs),
+        opacity: _data.slot.outOpacity(progressMs),
+      );
+    }
+    if (_data.toEndpoint != null) {
+      final incomingColor = _data.slot.color == null
+          ? _defaultTextColor
+          : Color.lerp(
+              _data.slot.color,
+              _defaultTextColor,
+              _data.slot.colorT(progressMs),
+            )!;
+      _paintTokenFace(
+        canvas,
+        text: _data.toText,
+        style: _data.effectiveToStyle.copyWith(color: incomingColor),
+        width: _data.metrics.toWidth,
+        dy: _data.slot.inY(progressMs, _data.travelDistance),
+        angle: _data.slot.tiltRadians * (1 - _data.slot.inT(progressMs)),
+        opacity: 1,
+      );
+    }
+
+    canvas.restore();
+  }
+
+  void _paintTokenFace(
+    Canvas canvas, {
+    required String text,
+    required TextStyle style,
+    required double width,
+    required double dy,
+    required double angle,
+    required double opacity,
+  }) {
+    if (text.isEmpty || opacity <= 0.001) {
+      return;
+    }
+
+    final height = _data.metrics.height;
+    final horizontalBleed = _horizontalTextTokenBleed(height);
+    final paintWidth = width + horizontalBleed;
+    final faceDx = _faceDxFor(width);
+    final paintDx = _paintDxFor(width, paintWidth);
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: _layout.textDirection,
+      textAlign: TextAlign.start,
+      textScaler: _textScaler,
+      locale: _layout.locale,
+      strutStyle: _layout.strutStyle,
+      maxLines: 1,
+    )..layout(minWidth: paintWidth, maxWidth: paintWidth);
+
+    canvas.save();
+    canvas.translate(faceDx + width / 2, dy + height / 2);
+    if (angle != 0) {
+      canvas.rotate(angle);
+    }
+    canvas.translate(-width / 2, -height / 2);
+
+    if (opacity < 0.999) {
+      canvas.saveLayer(
+        Rect.fromLTWH(paintDx, 0, paintWidth, height),
+        Paint()
+          ..color = Color.fromARGB(
+            (opacity.clamp(0.0, 1.0) * 255).round(),
+            255,
+            255,
+            255,
+          ),
+      );
+    }
+
+    painter.paint(canvas, Offset(paintDx, 0));
+
+    if (opacity < 0.999) {
+      canvas.restore();
+    }
+    canvas.restore();
+  }
+
+  double _faceDxFor(double width) {
+    return _layout.inlineStartAlignment
+        .alongOffset(
+          Offset(size.width - width, 0),
+        )
+        .dx;
+  }
+
+  double _paintDxFor(double width, double paintWidth) {
+    return _layout.textDirection == TextDirection.rtl
+        ? width - paintWidth
+        : 0.0;
+  }
 }
 
 class _VerticalSlotClipper extends CustomClipper<Rect> {

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -277,6 +277,8 @@ class _RenderRollingTextSlotFace extends RenderBox {
   _PreparedTextFace? _fromFace;
   _PreparedTextFace? _toFace;
   var _preparedFaceLayoutCount = 0;
+  var _disposedPreparedFaceLayoutCount = 0;
+  var _disposedTransientFaceLayoutCount = 0;
 
   _TokenSlotRenderData get data => _data;
 
@@ -356,6 +358,12 @@ class _RenderRollingTextSlotFace extends RenderBox {
 
   int get debugPreparedFaceLayoutCount => _preparedFaceLayoutCount;
 
+  int get debugDisposedPreparedFaceLayoutCount =>
+      _disposedPreparedFaceLayoutCount;
+
+  int get debugDisposedTransientFaceLayoutCount =>
+      _disposedTransientFaceLayoutCount;
+
   double get debugPreparedToFaceDx =>
       _toFace == null ? double.nan : _faceDxFor(_toFace!.width);
 
@@ -417,7 +425,14 @@ class _RenderRollingTextSlotFace extends RenderBox {
   @override
   void detach() {
     _animation.removeListener(_handleAnimationTick);
+    _clearPreparedFaces();
     super.detach();
+  }
+
+  @override
+  void dispose() {
+    _clearPreparedFaces();
+    super.dispose();
   }
 
   void _handleAnimationTick() {
@@ -437,7 +452,28 @@ class _RenderRollingTextSlotFace extends RenderBox {
 
   @override
   void performLayout() {
-    size = constraints.constrain(
+    size = _layoutSizeFor(constraints);
+  }
+
+  @override
+  Size computeDryLayout(covariant BoxConstraints constraints) {
+    return _layoutSizeFor(constraints);
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) => _currentWidth;
+
+  @override
+  double computeMaxIntrinsicWidth(double height) => _currentWidth;
+
+  @override
+  double computeMinIntrinsicHeight(double width) => _data.metrics.height;
+
+  @override
+  double computeMaxIntrinsicHeight(double width) => _data.metrics.height;
+
+  Size _layoutSizeFor(BoxConstraints constraints) {
+    return constraints.constrain(
       Size(_currentWidth, _data.metrics.height),
     );
   }
@@ -595,39 +631,65 @@ class _RenderRollingTextSlotFace extends RenderBox {
       locale: _layout.locale,
       strutStyle: _layout.strutStyle,
       maxLines: 1,
-    )..layout(minWidth: paintWidth, maxWidth: paintWidth);
+    );
+    var savedCanvas = false;
+    var savedLayer = false;
+    try {
+      painter.layout(minWidth: paintWidth, maxWidth: paintWidth);
 
-    canvas.save();
-    canvas.translate(faceDx + width / 2, dy + height / 2);
-    if (angle != 0) {
-      canvas.rotate(angle);
+      canvas.save();
+      savedCanvas = true;
+      canvas.translate(faceDx + width / 2, dy + height / 2);
+      if (angle != 0) {
+        canvas.rotate(angle);
+      }
+      canvas.translate(-width / 2, -height / 2);
+
+      if (opacity < 0.999) {
+        canvas.saveLayer(
+          Rect.fromLTWH(paintDx, 0, paintWidth, height),
+          Paint()
+            ..color = Color.fromARGB(
+              (opacity.clamp(0.0, 1.0) * 255).round(),
+              255,
+              255,
+              255,
+            ),
+        );
+        savedLayer = true;
+      }
+
+      painter.paint(canvas, Offset(paintDx, 0));
+
+      if (savedLayer) {
+        canvas.restore();
+        savedLayer = false;
+      }
+    } finally {
+      if (savedLayer) {
+        canvas.restore();
+      }
+      if (savedCanvas) {
+        canvas.restore();
+      }
+      painter.dispose();
+      _disposedTransientFaceLayoutCount++;
     }
-    canvas.translate(-width / 2, -height / 2);
-
-    if (opacity < 0.999) {
-      canvas.saveLayer(
-        Rect.fromLTWH(paintDx, 0, paintWidth, height),
-        Paint()
-          ..color = Color.fromARGB(
-            (opacity.clamp(0.0, 1.0) * 255).round(),
-            255,
-            255,
-            255,
-          ),
-      );
-    }
-
-    painter.paint(canvas, Offset(paintDx, 0));
-
-    if (opacity < 0.999) {
-      canvas.restore();
-    }
-    canvas.restore();
   }
 
   void _clearPreparedFaces() {
+    _disposedPreparedFaceLayoutCount +=
+        _disposePreparedFace(_fromFace) + _disposePreparedFace(_toFace);
     _fromFace = null;
     _toFace = null;
+  }
+
+  int _disposePreparedFace(_PreparedTextFace? face) {
+    if (face == null) {
+      return 0;
+    }
+    face.dispose();
+    return 1;
   }
 
   double _faceDxFor(double width) {
@@ -659,6 +721,10 @@ class _PreparedTextFace {
   final double height;
   final double paintWidth;
   final double paintDx;
+
+  void dispose() {
+    painter.dispose();
+  }
 }
 
 class _VerticalSlotClipper extends CustomClipper<Rect> {

--- a/lib/src/reel_text_widget.dart
+++ b/lib/src/reel_text_widget.dart
@@ -139,7 +139,9 @@ class _ReelTextState extends State<ReelText>
   _PendingRoll? _pending;
   Timer? _sequenceTimer;
   int _sequenceIndex = 0;
+  int _widgetSpanMetricsVersion = 0;
   final _widgetSpanSizes = _WidgetSpanSizeRegistry();
+  _SettledReelTextCache? _settledCache;
 
   String get _effectiveText =>
       widget.controller?.value ??
@@ -365,17 +367,22 @@ class _ReelTextState extends State<ReelText>
     final visibleFrame = _targetFrame ?? _displayedFrame;
     final visibleSemanticsText = visibleFrame.semanticsText;
     final roll = _roll;
-    final visibleContent =
-        roll?.to.content ?? _displayedFrame.contentFor(style);
+    final textScaler =
+        MediaQuery.maybeTextScalerOf(context) ?? TextScaler.noScaling;
+    late final _ReelTextContent visibleContent;
 
     Widget child;
     if (roll == null) {
-      child = _SettledReelText(
-        content: visibleContent,
-        key: const ValueKey('reel_text_settled'),
+      final settled = _settledReelTextFor(
+        frame: _displayedFrame,
+        style: style,
         layout: layout,
+        textScaler: textScaler,
       );
+      visibleContent = settled.measured.content;
+      child = settled.child;
     } else {
+      visibleContent = roll.to.content;
       child = _RollingReelText(
         plan: roll.plan,
         fromRun: roll.from.run,
@@ -431,6 +438,7 @@ class _ReelTextState extends State<ReelText>
     }
     setState(() {
       _widgetSpanSizes.setMetrics(index, span, metrics);
+      _widgetSpanMetricsVersion++;
       final targetFrame = _targetFrame;
       final roll = _roll;
       if (targetFrame != null && roll != null) {
@@ -458,6 +466,40 @@ class _ReelTextState extends State<ReelText>
       content: content,
       layout: layout,
     );
+  }
+
+  _SettledReelTextCache _settledReelTextFor({
+    required _ReelTextFrame frame,
+    required TextStyle style,
+    required _ReelTextLayoutContext layout,
+    required TextScaler textScaler,
+  }) {
+    final key = _SettledReelTextCacheKey(
+      frame: frame,
+      style: style,
+      textDirection: layout.textDirection,
+      locale: layout.locale,
+      strutStyle: layout.strutStyle,
+      textScaler: textScaler,
+      widgetSpanMetricsVersion: _widgetSpanMetricsVersion,
+    );
+    final cached = _settledCache;
+    if (cached != null && cached.key == key) {
+      return cached;
+    }
+
+    final measured = _measureFrame(frame, style, layout);
+    final next = _SettledReelTextCache(
+      key: key,
+      measured: measured,
+      child: _SettledReelText(
+        run: measured.run,
+        key: const ValueKey('reel_text_settled'),
+        layout: layout,
+      ),
+    );
+    _settledCache = next;
+    return next;
   }
 
   _ActiveRoll _createRoll(_ReelTextFrame targetFrame, ReelTextOptions options) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.3.0
+version: 0.4.0
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -1040,6 +1040,92 @@ void main() {
     expect(rollingWidth, lessThan(toWidth));
   });
 
+  testWidgets('painted rolling slots report intrinsic size during a roll', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('reel_intrinsic_width_roll');
+    const style = TextStyle(fontFamily: 'Ahem', fontSize: 24, height: 1);
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 200),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+      curve: Curves.linear,
+      bounce: 0,
+      skipUnchanged: false,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: IntrinsicWidth(
+            child: ReelText(
+              text,
+              key: reelKey,
+              style: style,
+              options: options,
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(frame(''));
+    await tester.pumpWidget(frame('A'));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(tester.takeException(), isNull);
+
+    final slotSize = tester.getSize(
+      find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+    );
+    final reelSize = tester.getSize(find.byKey(reelKey));
+
+    expect(slotSize.width, greaterThan(0));
+    expect(reelSize.width, closeTo(slotSize.width, 0.01));
+    expect(reelSize.height, closeTo(slotSize.height, 0.01));
+  });
+
+  testWidgets('painted rolling slots dispose text painters', (tester) async {
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 160),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+      curve: Curves.linear,
+      bounce: 0,
+      color: Colors.blue,
+      skipUnchanged: false,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReelText(text, options: options, style: _textStyle(32)),
+      );
+    }
+
+    await tester.pumpWidget(frame('A'));
+    await tester.pumpWidget(frame('B'));
+    await tester.pump();
+
+    final slot = tester.renderObject<RenderBox>(
+      find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+    );
+
+    expect(_debugPreparedFaceLayoutCount(slot), greaterThan(0));
+    expect(
+      (slot as dynamic).debugDisposedTransientFaceLayoutCount as int,
+      greaterThan(0),
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    expect(
+      (slot as dynamic).debugDisposedPreparedFaceLayoutCount as int,
+      greaterThan(0),
+    );
+  });
+
   testWidgets('glyph faces get paint bleed without reserving width', (
     tester,
   ) async {

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -932,6 +932,65 @@ void main() {
     expect(_debugPreparedFaceLayoutCount(slot), preparedLayouts);
   });
 
+  testWidgets('RTL prepared text face tracks animated slot width', (
+    tester,
+  ) async {
+    const options = ReelTextOptions(
+      direction: ReelTextDirection.down,
+      duration: Duration(milliseconds: 240),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+      curve: Curves.linear,
+      bounce: 0,
+      skipUnchanged: false,
+    );
+    const style = TextStyle(
+      fontFamily: 'Ahem',
+      fontSize: 48,
+      height: 1,
+      color: Colors.black,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: TextDirection.rtl,
+        child: SizedBox(
+          width: 180,
+          height: 120,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: ReelText(text, options: options, style: style),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(frame(''));
+    await tester.pumpWidget(frame('A'));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    final slot = tester.renderObject<RenderBox>(
+      find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+    );
+    final firstWidth = slot.size.width;
+    final firstPaintDx = (slot as dynamic).debugPreparedToFaceDx as double;
+    final firstCurrentDx = (slot as dynamic).debugCurrentToFaceDx as double;
+
+    expect(firstPaintDx, closeTo(firstCurrentDx, 0.01));
+
+    await tester.pump(const Duration(milliseconds: 60));
+
+    final secondPaintDx = (slot as dynamic).debugPreparedToFaceDx as double;
+    final secondCurrentDx = (slot as dynamic).debugCurrentToFaceDx as double;
+
+    expect(slot.size.width, greaterThan(firstWidth + 1));
+    expect((secondCurrentDx - firstCurrentDx).abs(), greaterThan(1));
+    expect(
+      secondPaintDx,
+      closeTo(secondCurrentDx, 0.01),
+    );
+  });
+
   testWidgets('inserted glyph widths expand during a roll', (tester) async {
     const reelKey = ValueKey('reel_interpolated_width');
     const style = TextStyle(

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -932,38 +932,6 @@ void main() {
     expect(_debugPreparedFaceLayoutCount(slot), preparedLayouts);
   });
 
-  testWidgets('rolling color fade uses a bounded prepared face cache', (
-    tester,
-  ) async {
-    const options = ReelTextOptions(
-      duration: Duration(milliseconds: 80),
-      stagger: Duration.zero,
-      exitOffset: Duration.zero,
-      color: Colors.blue,
-      colorFade: Duration(milliseconds: 120),
-    );
-
-    Widget frame(String text) {
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: ReelText(text, options: options, style: _textStyle(32)),
-      );
-    }
-
-    await tester.pumpWidget(frame('a'));
-    await tester.pumpWidget(frame('b'));
-    await tester.pump();
-
-    final slot = tester.renderObject<RenderBox>(
-      find.byKey(const ValueKey('reel_text_rolling_text_slot')),
-    );
-
-    expect(_debugPreparedFaceLayoutCount(slot), greaterThan(1));
-
-    await tester.pump(const Duration(milliseconds: 220));
-    expect(_debugPreparedFaceLayoutCount(slot), lessThanOrEqualTo(11));
-  });
-
   testWidgets('inserted glyph widths expand during a roll', (tester) async {
     const reelKey = ValueKey('reel_interpolated_width');
     const style = TextStyle(

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -165,6 +165,47 @@ void main() {
     );
   });
 
+  testWidgets('settled glyph subtree is reused across parent rebuilds', (
+    tester,
+  ) async {
+    var revision = 0;
+    late StateSetter rebuildParent;
+    final textScaler = _CountingTextScaler();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (context, setState) {
+            rebuildParent = setState;
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('revision $revision'),
+                MediaQuery(
+                  data: MediaQueryData(textScaler: textScaler),
+                  child: ReelText(
+                    'Stable',
+                    style: _textStyle(18),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+
+    final initialScaleCalls = textScaler.calls;
+    expect(initialScaleCalls, greaterThan(0));
+    rebuildParent(() {
+      revision++;
+    });
+    await tester.pump();
+
+    expect(textScaler.calls, initialScaleCalls);
+  });
+
   testWidgets('settled locale layout matches Text size exactly', (
     tester,
   ) async {
@@ -779,6 +820,38 @@ void main() {
 
     await tester.pumpAndSettle();
     expect(tester.getSize(find.byKey(reelKey)), targetSize);
+  });
+
+  testWidgets('rolling uses per-slot builders only for changed text slots', (
+    tester,
+  ) async {
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 120),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+    );
+
+    TextSpan spanFor(String middle) {
+      return TextSpan(
+        children: [
+          TextSpan(text: 'a', style: _textStyle(11)),
+          TextSpan(text: middle, style: _textStyle(17)),
+          TextSpan(text: 'c', style: _textStyle(13)),
+        ],
+      );
+    }
+
+    Widget frame(String middle) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReelText.rich(spanFor(middle), options: options),
+      );
+    }
+
+    await tester.pumpWidget(frame('b'));
+    await tester.pumpWidget(frame('x'));
+
+    expect(find.byType(AnimatedBuilder), findsNWidgets(2));
   });
 
   testWidgets('inserted glyph widths expand during a roll', (tester) async {
@@ -3723,4 +3796,23 @@ class _GlyphPosition {
   final String text;
   final double left;
   final int sourceOrder;
+}
+
+TextStyle _textStyle(double fontSize) {
+  return TextStyle(fontSize: fontSize);
+}
+
+class _CountingTextScaler extends TextScaler {
+  final scaledFontSizes = <double>[];
+
+  int get calls => scaledFontSizes.length;
+
+  @override
+  double scale(double fontSize) {
+    scaledFontSizes.add(fontSize);
+    return fontSize;
+  }
+
+  @override
+  double get textScaleFactor => 1;
 }

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -898,6 +898,40 @@ void main() {
     );
   });
 
+  testWidgets('rolling text slot reuses prepared face layouts while painting', (
+    tester,
+  ) async {
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 180),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReelText(text, options: options, style: _textStyle(32)),
+      );
+    }
+
+    await tester.pumpWidget(frame('a'));
+    await tester.pumpWidget(frame('b'));
+    await tester.pump();
+
+    final slot = tester.renderObject<RenderBox>(
+      find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+    );
+    final preparedLayouts = _debugPreparedFaceLayoutCount(slot);
+
+    expect(preparedLayouts, greaterThan(0));
+
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(_debugPreparedFaceLayoutCount(slot), preparedLayouts);
+
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(_debugPreparedFaceLayoutCount(slot), preparedLayouts);
+  });
+
   testWidgets('inserted glyph widths expand during a roll', (tester) async {
     const reelKey = ValueKey('reel_interpolated_width');
     const style = TextStyle(
@@ -3796,6 +3830,14 @@ bool _isEffectivelyOpaque(Element element) {
     return true;
   });
   return opaque;
+}
+
+int _debugPreparedFaceLayoutCount(RenderBox renderObject) {
+  try {
+    return (renderObject as dynamic).debugPreparedFaceLayoutCount as int;
+  } on Object {
+    return -1;
+  }
 }
 
 double _leftOfGlyph(List<_GlyphPosition> entries, String glyph) {

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -822,7 +822,7 @@ void main() {
     expect(tester.getSize(find.byKey(reelKey)), targetSize);
   });
 
-  testWidgets('rolling uses per-slot builders only for changed text slots', (
+  testWidgets('rolling LTR text slots paint without slot builders', (
     tester,
   ) async {
     const options = ReelTextOptions(
@@ -851,7 +851,51 @@ void main() {
     await tester.pumpWidget(frame('b'));
     await tester.pumpWidget(frame('x'));
 
-    expect(find.byType(AnimatedBuilder), findsNWidgets(2));
+    final rolling = find.byKey(const ValueKey('reel_text_rolling'));
+
+    expect(find.byType(AnimatedBuilder), findsOneWidget);
+    expect(
+      find.descendant(
+        of: rolling,
+        matching: find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: rolling, matching: find.byType(Text)),
+      findsNWidgets(2),
+    );
+  });
+
+  testWidgets('rolling RTL text slots paint without slot builders', (
+    tester,
+  ) async {
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 120),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: TextDirection.rtl,
+        child: ReelText(text, options: options),
+      );
+    }
+
+    await tester.pumpWidget(frame('אבג'));
+    await tester.pumpWidget(frame('אבד'));
+
+    final rolling = find.byKey(const ValueKey('reel_text_rolling'));
+
+    expect(find.byType(AnimatedBuilder), findsOneWidget);
+    expect(
+      find.descendant(
+        of: rolling,
+        matching: find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('inserted glyph widths expand during a roll', (tester) async {
@@ -937,16 +981,15 @@ void main() {
     await tester.pump(const Duration(milliseconds: 80));
 
     final rollingWidth = tester.getSize(find.byKey(reelKey)).width;
-    final finiteFaceWidths = tester
-        .widgetList<OverflowBox>(find.byType(OverflowBox))
-        .map((box) => box.maxWidth)
-        .whereType<double>()
-        .where((width) => width.isFinite)
-        .toList();
+    final rollingSlot = find.byKey(
+      const ValueKey('reel_text_rolling_text_slot'),
+    );
+    final rollingSlotRender = tester.renderObject(rollingSlot) as dynamic;
 
     expect(rollingWidth, greaterThan(0));
     expect(rollingWidth, lessThan(painter.size.width));
-    expect(finiteFaceWidths, contains(greaterThan(painter.size.width + 3)));
+    expect(tester.getSize(rollingSlot).width, closeTo(rollingWidth, 0.01));
+    expect(rollingSlotRender.debugHorizontalBleed, greaterThan(3));
 
     await tester.pumpAndSettle();
 
@@ -3111,14 +3154,11 @@ void main() {
       final clipFinder = find.byType(ClipRect).first;
       final clip = tester.widget<ClipRect>(clipFinder);
       final clipRect = clip.clipper!.getClip(tester.getSize(clipFinder));
-      final translations = tester
-          .widgetList<Transform>(find.byType(Transform))
-          .map((widget) => widget.transform.getTranslation().y)
-          .where((dy) => dy.abs() > 0.01)
-          .toList();
+      final rollingSlotRender = tester.renderObject(
+        find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+      ) as dynamic;
 
-      expect(translations, hasLength(1));
-      expect(translations.single, greaterThan(clipRect.bottom));
+      expect(rollingSlotRender.debugIncomingY, greaterThan(clipRect.bottom));
     },
   );
 
@@ -3713,6 +3753,32 @@ List<_GlyphPosition> _visibleReelGlyphPositionsLeftToRight(
       continue;
     }
     entries.add(_GlyphPosition(text, rect.left, entries.length));
+  }
+  final paintedSlotFinder = find.descendant(
+    of: scope,
+    matching: find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+  );
+  for (final element in paintedSlotFinder.evaluate()) {
+    final renderObject = element.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.attached) {
+      continue;
+    }
+    final slotTopLeft = renderObject.localToGlobal(Offset.zero);
+    final bounds = (renderObject as dynamic).debugVisibleGlyphBounds as List;
+    for (final rawBound in bounds) {
+      final bound = rawBound as Map;
+      final text = bound['text'] as String;
+      if (text.trim().isEmpty) {
+        continue;
+      }
+      final top = slotTopLeft.dy + (bound['top'] as double);
+      final bottom = slotTopLeft.dy + (bound['bottom'] as double);
+      if (bottom <= scopeRect.top || top >= scopeRect.bottom) {
+        continue;
+      }
+      final left = slotTopLeft.dx + (bound['left'] as double);
+      entries.add(_GlyphPosition(text, left, entries.length));
+    }
   }
 
   entries.sort(_compareGlyphPositions);

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -932,6 +932,38 @@ void main() {
     expect(_debugPreparedFaceLayoutCount(slot), preparedLayouts);
   });
 
+  testWidgets('rolling color fade uses a bounded prepared face cache', (
+    tester,
+  ) async {
+    const options = ReelTextOptions(
+      duration: Duration(milliseconds: 80),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+      color: Colors.blue,
+      colorFade: Duration(milliseconds: 120),
+    );
+
+    Widget frame(String text) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReelText(text, options: options, style: _textStyle(32)),
+      );
+    }
+
+    await tester.pumpWidget(frame('a'));
+    await tester.pumpWidget(frame('b'));
+    await tester.pump();
+
+    final slot = tester.renderObject<RenderBox>(
+      find.byKey(const ValueKey('reel_text_rolling_text_slot')),
+    );
+
+    expect(_debugPreparedFaceLayoutCount(slot), greaterThan(1));
+
+    await tester.pump(const Duration(milliseconds: 220));
+    expect(_debugPreparedFaceLayoutCount(slot), lessThanOrEqualTo(11));
+  });
+
   testWidgets('inserted glyph widths expand during a roll', (tester) async {
     const reelKey = ValueKey('reel_interpolated_width');
     const style = TextStyle(


### PR DESCRIPTION
## Summary

This PR reduces unnecessary rebuild, measurement, and per-frame widget work in `ReelText` without changing the public API, and adds a dedicated example stress screen for visual/performance checks.

- Settled text now reuses a measured run when text, style, and layout inputs are unchanged, so parent rebuilds do not repeatedly split and measure the same glyph run.
- Rolling rows now keep the slot row outside the animation tick; the `AnimatedBuilder` updates viewport sizing/alignment while slots receive the animation directly.
- Changed plain-text slots paint through a lightweight render-object path that prepares glyph face layouts once and reuses them while the animation progresses.
- `WidgetSpan` slots intentionally stay on the widget path because they are live child widgets with layout, baseline, semantics, keys, and selection behavior.
- The example app now has a fourth Performance tab with a full-screen checkerboard of independent `ReelText` widgets, theme support, edge fade, optional frame logging, and a tile-count slider that starts at 4 tiles and scales up to the stress maximum.

## Notes

- The temporary chroma/color toggles were removed because disabling them did not improve FPS and made the performance panel noisier.
- The reverted rolling color-face cache experiment is not part of the final effective diff.

## Validation

- `flutter test test/reel_text_test.dart`
- `cd example && flutter test test/widget_test.dart`
- `cd example && flutter analyze`
- `git diff --check`