### PR TITLE
[codex] Pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -18,11 +16,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true
@@ -36,16 +36,19 @@ jobs:
         run: flutter build web --release --base-href "/reel_text/"
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: example/build/web
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -53,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true
@@ -70,6 +70,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
     with:
       environment: pub.dev


### PR DESCRIPTION
## Summary

- Pin external GitHub Actions and the pub.dev reusable publish workflow to immutable full commit SHAs.
- Narrow the Pages workflow permissions so only the deploy job receives `pages: write` and `id-token: write`.
- Keep tag comments beside each pin to make future dependency updates easier to review.

## Why

The security scan found two supply-chain hardening issues: privileged workflows used mutable `@vN` refs, and the Pages workflow granted deploy/OIDC authority at workflow scope. Pinning refs and narrowing permissions reduces the blast radius of upstream tag movement or action compromise.

## Validation

- Parsed `.github/workflows/*.yml` successfully.
- `flutter analyze`
- `flutter test`
- `flutter analyze` from `example/`
- `flutter test` from `example/`
- `dart pub publish --dry-run` (`reel_text 0.4.0`, 0 warnings)
- `rg "uses: .*@(v[0-9]+|main|master|stable)" .github/workflows` found no mutable workflow refs.

## Notes

The previous security report mentioned `0.1.6` because the local checkout used for the scan was stale. This branch is based on the current `origin/main` at `v0.4.0`.