### PR TITLE
Fix editable replacement baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.1
+
+- Fixed vertical alignment for `ReelTextEditingController` replacements inside
+  `EditableText` and `TextField`, including active rolling replacements that
+  rely on Flutter's dry layout and baseline placeholder metrics.
+- Preserved the surrounding editable text strut for inline replacement widgets.
+- No public API changes.
+
 ## 0.4.0
 
 - Reworked plain rolling text slots to paint through cached render objects,

--- a/example/lib/editor_page.dart
+++ b/example/lib/editor_page.dart
@@ -117,7 +117,7 @@ class _EditorPageState extends State<EditorPage> {
           style: Studio.mono(
             size: 13,
             color: Studio.text,
-            height: 1.1,
+            height: 1,
             weight: FontWeight.w700,
           ),
         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1297,6 +1297,8 @@ void main() {
     );
     expect(targetReplacement.controller!.value, 'Export ready');
     expect(targetReplacement.options.direction, ReelTextDirection.down);
+    expect(targetReplacement.style?.height, 1);
+    expect(targetReplacement.strutStyle?.forceStrutHeight, isTrue);
     expect(
       find.descendant(
         of: find.byKey(const ValueKey('editor_target_replacement')),
@@ -1339,6 +1341,43 @@ void main() {
     await tester.pump(const Duration(milliseconds: 16));
     expect(find.byKey(const ValueKey('reel_text_rolling')), findsWidgets);
     expect(preview.controller!.value, 'Export ready');
+  });
+
+  testWidgets('editor target input keeps height while animating target chips', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const ReelTextExampleApp(useGoogleFonts: false, autoPlayHero: false),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.byKey(const ValueKey('page_tab_editor')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final input = find.byKey(const ValueKey('editor_target_input'));
+    final editable = find.descendant(
+      of: input,
+      matching: find.byType(EditableText),
+    );
+    final restingHeight = tester.getSize(editable).height;
+
+    await tester.tap(find.byKey(const ValueKey('editor_target_invite_copied')));
+    await tester.pump();
+    final replacementHeight = tester.getSize(editable).height;
+    final targetReplacement = tester.widget<ReelText>(
+      find.byKey(const ValueKey('editor_target_replacement')),
+    );
+    expect(targetReplacement.strutStyle?.forceStrutHeight, isTrue);
+    expect(replacementHeight, restingHeight);
+
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(find.byKey(const ValueKey('reel_text_rolling')), findsWidgets);
+    expect(tester.getSize(editable).height, restingHeight);
+
+    await tester.pumpAndSettle();
+    expect(tester.getSize(editable).height, restingHeight);
   });
 
   testWidgets('editor light theme primary controls use white foreground', (

--- a/lib/src/reel_text_editing.dart
+++ b/lib/src/reel_text_editing.dart
@@ -231,6 +231,7 @@ class ReelTextEditingController extends TextEditingController {
     }
 
     final baseStyle = style ?? const TextStyle();
+    final strutStyle = _editableTextStrutStyleOf(context);
     final children = <InlineSpan>[];
     var cursor = 0;
     for (final active in _activeReplacements) {
@@ -252,6 +253,7 @@ class ReelTextEditingController extends TextEditingController {
             style: replacement.style == null
                 ? baseStyle
                 : baseStyle.merge(replacement.style),
+            strutStyle: strutStyle,
           ),
         ),
       );
@@ -274,6 +276,14 @@ class ReelTextEditingController extends TextEditingController {
     _autoCommitTimer?.cancel();
     _autoCommitTimer = null;
   }
+}
+
+StrutStyle? _editableTextStrutStyleOf(BuildContext context) {
+  final widget = context.widget;
+  if (widget is EditableText) {
+    return widget.strutStyle;
+  }
+  return context.findAncestorWidgetOfExactType<EditableText>()?.strutStyle;
 }
 
 class _ActiveReelTextReplacement {

--- a/lib/src/reel_text_metrics.dart
+++ b/lib/src/reel_text_metrics.dart
@@ -337,11 +337,22 @@ class _SlotMetrics {
     required this.fromWidth,
     required this.toWidth,
     required this.height,
+    required this.alphabeticBaseline,
+    required this.ideographicBaseline,
   });
 
   final double fromWidth;
   final double toWidth;
   final double height;
+  final double alphabeticBaseline;
+  final double ideographicBaseline;
+
+  double baselineFor(TextBaseline baseline) {
+    return switch (baseline) {
+      TextBaseline.ideographic => ideographicBaseline,
+      TextBaseline.alphabetic => alphabeticBaseline,
+    };
+  }
 }
 
 Alignment _inlineStartAlignment(TextDirection textDirection) {

--- a/lib/src/reel_text_runs.dart
+++ b/lib/src/reel_text_runs.dart
@@ -127,6 +127,26 @@ class _RenderSettledTokenRowViewport extends RenderShiftedBox {
       ),
     );
   }
+
+  @override
+  Size computeDryLayout(covariant BoxConstraints constraints) {
+    final child = this.child;
+    if (child == null) {
+      return constraints.constrain(Size(0, height));
+    }
+
+    final childSize = child.getDryLayout(
+      const BoxConstraints(
+        minWidth: 0,
+        maxWidth: double.infinity,
+        minHeight: 0,
+        maxHeight: double.infinity,
+      ),
+    );
+    return constraints.constrain(
+      Size(childSize.width, math.max(height, childSize.height)),
+    );
+  }
 }
 
 class _RollingReelText extends StatelessWidget {

--- a/lib/src/reel_text_slots.dart
+++ b/lib/src/reel_text_slots.dart
@@ -77,6 +77,14 @@ class _RollingTokenSlot extends StatelessWidget {
         fromWidth: fromRun.widthFor(slot.from),
         toWidth: toRun.widthFor(slot.to),
         height: math.max(fromRun.height, toRun.height),
+        alphabeticBaseline: math.max(
+          fromRun.metrics.alphabeticBaseline,
+          toRun.metrics.alphabeticBaseline,
+        ),
+        ideographicBaseline: math.max(
+          fromRun.metrics.ideographicBaseline,
+          toRun.metrics.ideographicBaseline,
+        ),
       ),
     );
     if (!slot.changed) {
@@ -471,6 +479,19 @@ class _RenderRollingTextSlotFace extends RenderBox {
 
   @override
   double computeMaxIntrinsicHeight(double width) => _data.metrics.height;
+
+  @override
+  double? computeDistanceToActualBaseline(TextBaseline baseline) {
+    return _data.metrics.baselineFor(baseline);
+  }
+
+  @override
+  double? computeDryBaseline(
+    covariant BoxConstraints constraints,
+    TextBaseline baseline,
+  ) {
+    return _data.metrics.baselineFor(baseline);
+  }
 
   Size _layoutSizeFor(BoxConstraints constraints) {
     return constraints.constrain(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.4.0
+version: 0.4.1
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -165,6 +165,112 @@ void main() {
     );
   });
 
+  testWidgets('settled layout exposes Text-like alphabetic baseline', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('reel_baseline_reel');
+    const textKey = ValueKey('reel_baseline_text');
+    const text = 'Invite copied';
+    const style = TextStyle(fontSize: 13, height: 1);
+    const strut = StrutStyle(fontSize: 13, height: 1, forceStrutHeight: true);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            Text(text, key: textKey, style: style, strutStyle: strut),
+            ReelText(text, key: reelKey, style: style, strutStyle: strut),
+          ],
+        ),
+      ),
+    );
+
+    expect(
+      tester.getTopLeft(find.byKey(reelKey)).dy,
+      tester.getTopLeft(find.byKey(textKey)).dy,
+    );
+
+    final reelBox = tester.renderObject<RenderBox>(find.byKey(reelKey));
+    final textBox = tester.renderObject<RenderBox>(find.byKey(textKey));
+    final reelSize = tester.getSize(find.byKey(reelKey));
+    final textSize = tester.getSize(find.byKey(textKey));
+    final dryBaseline = reelBox.getDryBaseline(
+      BoxConstraints.tight(reelSize),
+      TextBaseline.alphabetic,
+    );
+    final textDryBaseline = textBox.getDryBaseline(
+      BoxConstraints.tight(textSize),
+      TextBaseline.alphabetic,
+    );
+    expect(dryBaseline, closeTo(textDryBaseline!, 0.001));
+  });
+
+  testWidgets('rolling layout exposes Text-like alphabetic baseline', (
+    tester,
+  ) async {
+    const reelKey = ValueKey('reel_rolling_baseline_reel');
+    const textKey = ValueKey('reel_rolling_baseline_text');
+    const style = TextStyle(fontSize: 13, height: 1);
+    const strut = StrutStyle(fontSize: 13, height: 1, forceStrutHeight: true);
+    final controller = ReelTextController(initialText: 'Cart updated');
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            const Text(
+              'Invite copied',
+              key: textKey,
+              style: style,
+              strutStyle: strut,
+            ),
+            ReelText.controller(
+              key: reelKey,
+              controller: controller,
+              style: style,
+              strutStyle: strut,
+              options: const ReelTextOptions(
+                duration: Duration(milliseconds: 120),
+                stagger: Duration.zero,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    controller.set('Invite copied');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(find.byKey(const ValueKey('reel_text_rolling')), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.byKey(reelKey)).dy,
+      tester.getTopLeft(find.byKey(textKey)).dy,
+    );
+
+    final reelBox = tester.renderObject<RenderBox>(find.byKey(reelKey));
+    final textBox = tester.renderObject<RenderBox>(find.byKey(textKey));
+    final reelSize = tester.getSize(find.byKey(reelKey));
+    final textSize = tester.getSize(find.byKey(textKey));
+    final dryBaseline = reelBox.getDryBaseline(
+      BoxConstraints.tight(reelSize),
+      TextBaseline.alphabetic,
+    );
+    final textDryBaseline = textBox.getDryBaseline(
+      BoxConstraints.tight(textSize),
+      TextBaseline.alphabetic,
+    );
+    expect(dryBaseline, closeTo(textDryBaseline!, 0.001));
+  });
+
   testWidgets('settled glyph subtree is reused across parent rebuilds', (
     tester,
   ) async {
@@ -2857,6 +2963,45 @@ void main() {
       expect(controller.replacementText(), 'Fix the typo.');
     },
   );
+
+  testWidgets(
+      'editing controller preserves EditableText strut for replacements', (
+    tester,
+  ) async {
+    const inlineKey = ValueKey('inline_strut_replacement');
+    const strut = StrutStyle(fontSize: 13, height: 1, forceStrutHeight: true);
+    final controller = ReelTextEditingController(text: 'Invite copied');
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditableText(
+          controller: controller,
+          focusNode: focusNode,
+          style: const TextStyle(fontSize: 13, height: 1),
+          strutStyle: strut,
+          cursorColor: Colors.green,
+          backgroundCursorColor: Colors.black,
+        ),
+      ),
+    );
+
+    controller.beginReplacements([
+      const ReelTextEditReplacement(
+        range: TextRange(start: 0, end: 13),
+        replacement: 'Export ready',
+        key: inlineKey,
+      ),
+    ]);
+    await tester.pump();
+
+    final inlineReplacement = tester.widget<ReelText>(find.byKey(inlineKey));
+    expect(inlineReplacement.strutStyle?.fontSize, strut.fontSize);
+    expect(inlineReplacement.strutStyle?.height, strut.height);
+    expect(inlineReplacement.strutStyle?.forceStrutHeight, isTrue);
+  });
 
   testWidgets('editing controller spanBuilder customizes resting text', (
     tester,


### PR DESCRIPTION
## Summary
- fix inline editable replacement alignment by preserving editable strut and dry baseline metrics
- add settled and rolling baseline regressions for Text-like layout
- bump release metadata to 0.4.1

## Verification
- flutter test
- cd example && flutter test
- flutter analyze
- dart pub publish --dry-run