### PR TITLE
Prepare reel_text 0.4.2 reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.4.2
+
+- Discarded transitions queued by a previous `ReelTextController` when a
+  `ReelText` widget switches controllers, preventing stale targets from being
+  applied later.
+- Validated animation durations, waiting intervals, and bounce values before
+  mutating controller state, with consistent `ArgumentError` failures for
+  invalid input.
+- Disposed temporary `TextPainter` instances after text-run measurement on
+  both success and exception paths.
+- Updated the example app to `google_fonts` 8.2.0.
+- No public API changes.
+
 ## 0.4.1
 
 - Fixed vertical alignment for `ReelTextEditingController` replacements inside

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.4.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/lib/src/reel_text_api.dart
+++ b/lib/src/reel_text_api.dart
@@ -306,3 +306,29 @@ ReelTextColorBuilder chromatic({
     return HSLColor.fromAHSL(1, hue, saturation, lightness).toColor();
   };
 }
+
+void _validateReelTextOptions(ReelTextOptions options) {
+  _requireNonNegativeDuration(options.stagger, 'options.stagger');
+  _requireNonNegativeDuration(options.duration, 'options.duration');
+  _requireNonNegativeDuration(options.exitOffset, 'options.exitOffset');
+  _requireNonNegativeDuration(options.colorFade, 'options.colorFade');
+  if (!options.bounce.isFinite || options.bounce < 0) {
+    throw ArgumentError.value(
+      options.bounce,
+      'options.bounce',
+      'must be finite and non-negative',
+    );
+  }
+}
+
+void _requireNonNegativeDuration(Duration value, String name) {
+  if (value.isNegative) {
+    throw ArgumentError.value(value, name, 'must not be negative');
+  }
+}
+
+void _requirePositiveDuration(Duration value, String name) {
+  if (value <= Duration.zero) {
+    throw ArgumentError.value(value, name, 'must be greater than zero');
+  }
+}

--- a/lib/src/reel_text_controller.dart
+++ b/lib/src/reel_text_controller.dart
@@ -19,6 +19,9 @@ class ReelTextController extends ChangeNotifier {
 
   /// Permanently rolls to [text] and cancels any pending flash revert.
   void set(String text, {ReelTextOptions? options}) {
+    if (options != null) {
+      _validateReelTextOptions(options);
+    }
     _cancelFlash();
     _cancelProgress();
     _emit(text, options);
@@ -31,22 +34,23 @@ class ReelTextController extends ChangeNotifier {
     String text, {
     ReelTextFlashOptions options = const ReelTextFlashOptions(),
   }) {
+    _requireNonNegativeDuration(options.revertAfter, 'options.revertAfter');
+    final enterOptions =
+        (options.enter ?? const ReelTextOptions()).copyWith(interrupt: false);
+    final exitOptions =
+        (options.exit ?? const ReelTextOptions()).copyWith(interrupt: false);
+    _validateReelTextOptions(enterOptions);
+    _validateReelTextOptions(exitOptions);
     _cancelProgress();
     _restingText ??= _value;
-    _emit(
-      text,
-      (options.enter ?? const ReelTextOptions()).copyWith(interrupt: false),
-    );
+    _emit(text, enterOptions);
 
     _revertTimer?.cancel();
     _revertTimer = Timer(options.revertAfter, () {
       final back = _restingText!;
       _restingText = null;
       _revertTimer = null;
-      _emit(
-        back,
-        (options.exit ?? const ReelTextOptions()).copyWith(interrupt: false),
-      );
+      _emit(back, exitOptions);
     });
   }
 
@@ -66,6 +70,9 @@ class ReelTextController extends ChangeNotifier {
     Duration? interval,
     bool animateUnchanged = false,
   }) {
+    if (interval != null) {
+      _requirePositiveDuration(interval, 'interval');
+    }
     final sequence = frames.isEmpty
         ? <String>[text]
         : frames.first == text
@@ -75,6 +82,7 @@ class ReelTextController extends ChangeNotifier {
       interrupt: false,
       skipUnchanged: !animateUnchanged,
     );
+    _validateReelTextOptions(progressOptions);
     final tickInterval = interval ??
         Duration(
           milliseconds: (progressOptions.duration.inMilliseconds * 0.55)
@@ -132,6 +140,11 @@ class ReelTextController extends ChangeNotifier {
     ReelWaiting waiting = const ReelWaiting.ellipsis(),
     ReelTextOptions? options,
   }) {
+    final step = waiting.step;
+    if (step != null) {
+      _requirePositiveDuration(step, 'waiting.step');
+    }
+    _requireNonNegativeDuration(waiting.rest, 'waiting.rest');
     switch (waiting._kind) {
       case _ReelWaitingKind.ellipsis:
         final base = options ?? _tickWaitingDefaults;
@@ -290,6 +303,9 @@ class ReelTextController extends ChangeNotifier {
     if (!_isProgressActive(epoch)) {
       return;
     }
+    if (options != null) {
+      _validateReelTextOptions(options);
+    }
     _cancelProgress();
     _emit(text, options);
   }
@@ -301,6 +317,9 @@ class ReelTextController extends ChangeNotifier {
   }) {
     if (!_isProgressActive(epoch)) {
       return;
+    }
+    if (text != null && options != null) {
+      _validateReelTextOptions(options);
     }
     _cancelProgress();
     if (text != null) {
@@ -325,6 +344,9 @@ class ReelTextController extends ChangeNotifier {
   }
 
   void _emit(String text, ReelTextOptions? options, {bool force = false}) {
+    if (options != null) {
+      _validateReelTextOptions(options);
+    }
     _value = text;
     _command = _ReelTextCommand(text, options, force: force);
     notifyListeners();

--- a/lib/src/reel_text_controller.dart
+++ b/lib/src/reel_text_controller.dart
@@ -145,9 +145,13 @@ class ReelTextController extends ChangeNotifier {
       _requirePositiveDuration(step, 'waiting.step');
     }
     _requireNonNegativeDuration(waiting.rest, 'waiting.rest');
+    final base = options ??
+        (waiting._kind == _ReelWaitingKind.wave
+            ? _waveWaitingDefaults
+            : _tickWaitingDefaults);
+    _validateReelTextOptions(base);
     switch (waiting._kind) {
       case _ReelWaitingKind.ellipsis:
-        final base = options ?? _tickWaitingDefaults;
         return startProgress(
           text,
           frames: <String>[
@@ -157,7 +161,6 @@ class ReelTextController extends ChangeNotifier {
           options: base,
         );
       case _ReelWaitingKind.wave:
-        final base = options ?? _waveWaitingDefaults;
         final glyphCount = math.max(1, text.characters.length);
         final sweepMs = (glyphCount - 1) * base.stagger.inMilliseconds +
             base.exitOffset.inMilliseconds +
@@ -173,7 +176,6 @@ class ReelTextController extends ChangeNotifier {
           options: base,
         );
       case _ReelWaitingKind.frames:
-        final base = options ?? _tickWaitingDefaults;
         return startProgress(
           text,
           frames: waiting.frames,
@@ -181,7 +183,6 @@ class ReelTextController extends ChangeNotifier {
           options: base,
         );
       case _ReelWaitingKind.builder:
-        final base = options ?? _tickWaitingDefaults;
         final frame = waiting.frameBuilder!;
         return _startFrameLoop(
           initial: frame(text, 0),
@@ -190,7 +191,6 @@ class ReelTextController extends ChangeNotifier {
           options: base.copyWith(interrupt: false),
         );
       case _ReelWaitingKind.scramble:
-        final base = options ?? _tickWaitingDefaults;
         return _startFrameLoop(
           initial: text,
           frameAt: (tick) => _scrambleFrame(text, tick, waiting),

--- a/lib/src/reel_text_metrics.dart
+++ b/lib/src/reel_text_metrics.dart
@@ -193,65 +193,69 @@ class _TextRunMetrics {
       strutStyle: layout.strutStyle,
       maxLines: 1,
     );
-    painter.setPlaceholderDimensions(
-      _placeholderDimensionsFor(content, layout.widgetSpanMetricsFor),
-    );
-    painter.layout();
+    try {
+      painter.setPlaceholderDimensions(
+        _placeholderDimensionsFor(content, layout.widgetSpanMetricsFor),
+      );
+      painter.layout();
 
-    final tokens = content.tokens;
-    final offsets = <int>[0];
-    var offset = 0;
-    for (final token in tokens) {
-      offset += token.text.length;
-      offsets.add(offset);
-    }
-
-    final widths = <double>[];
-    final visualLefts = <double>[];
-    for (var i = 0; i < tokens.length; i++) {
-      final bounds = _tokenBounds(painter, offsets[i], offsets[i + 1]);
-      widths.add(bounds.width);
-      visualLefts.add(bounds.left);
-    }
-
-    final measured = widths.fold<double>(0, (sum, width) => sum + width);
-    if (widths.isNotEmpty && (measured - painter.size.width).abs() > 1e-9) {
-      final index = widths.lastIndexWhere((width) => width > 0);
-      if (index >= 0) {
-        widths[index] = math.max(
-          0,
-          widths[index] + painter.size.width - measured,
-        );
+      final tokens = content.tokens;
+      final offsets = <int>[0];
+      var offset = 0;
+      for (final token in tokens) {
+        offset += token.text.length;
+        offsets.add(offset);
       }
-    }
 
-    final totalWidth = widths.fold<double>(0, (sum, width) => sum + width);
-    final visualOrder = [for (var i = 0; i < tokens.length; i++) i]
-      ..sort((a, b) {
-        final byLeft = visualLefts[a].compareTo(visualLefts[b]);
-        if (byLeft != 0) {
-          return byLeft;
+      final widths = <double>[];
+      final visualLefts = <double>[];
+      for (var i = 0; i < tokens.length; i++) {
+        final bounds = _tokenBounds(painter, offsets[i], offsets[i + 1]);
+        widths.add(bounds.width);
+        visualLefts.add(bounds.left);
+      }
+
+      final measured = widths.fold<double>(0, (sum, width) => sum + width);
+      if (widths.isNotEmpty && (measured - painter.size.width).abs() > 1e-9) {
+        final index = widths.lastIndexWhere((width) => width > 0);
+        if (index >= 0) {
+          widths[index] = math.max(
+            0,
+            widths[index] + painter.size.width - measured,
+          );
         }
-        final byRight = (visualLefts[a] + widths[a]).compareTo(
-          visualLefts[b] + widths[b],
-        );
-        if (byRight != 0) {
-          return byRight;
-        }
-        return a.compareTo(b);
-      });
-    return _TextRunMetrics(
-      widths: widths,
-      visualOrder: visualOrder,
-      width: totalWidth,
-      height: painter.size.height,
-      alphabeticBaseline: painter.computeDistanceToActualBaseline(
-        TextBaseline.alphabetic,
-      ),
-      ideographicBaseline: painter.computeDistanceToActualBaseline(
-        TextBaseline.ideographic,
-      ),
-    );
+      }
+
+      final totalWidth = widths.fold<double>(0, (sum, width) => sum + width);
+      final visualOrder = [for (var i = 0; i < tokens.length; i++) i]
+        ..sort((a, b) {
+          final byLeft = visualLefts[a].compareTo(visualLefts[b]);
+          if (byLeft != 0) {
+            return byLeft;
+          }
+          final byRight = (visualLefts[a] + widths[a]).compareTo(
+            visualLefts[b] + widths[b],
+          );
+          if (byRight != 0) {
+            return byRight;
+          }
+          return a.compareTo(b);
+        });
+      return _TextRunMetrics(
+        widths: widths,
+        visualOrder: visualOrder,
+        width: totalWidth,
+        height: painter.size.height,
+        alphabeticBaseline: painter.computeDistanceToActualBaseline(
+          TextBaseline.alphabetic,
+        ),
+        ideographicBaseline: painter.computeDistanceToActualBaseline(
+          TextBaseline.ideographic,
+        ),
+      );
+    } finally {
+      painter.dispose();
+    }
   }
 
   static double _caretDx(TextPainter painter, int offset) {

--- a/lib/src/reel_text_widget.dart
+++ b/lib/src/reel_text_widget.dart
@@ -205,6 +205,7 @@ class _ReelTextState extends State<ReelText>
       _displayedFrame = _effectiveFrame;
       _targetFrame = null;
       _roll = null;
+      _pending = null;
       _controller.stop();
     } else if (widget.controller == null &&
         (oldWidget.text != widget.text ||
@@ -245,6 +246,7 @@ class _ReelTextState extends State<ReelText>
     if (values == null || values.length < 2) {
       return;
     }
+    _requirePositiveDuration(widget._sequenceInterval!, 'interval');
     _sequenceTimer = Timer.periodic(widget._sequenceInterval!, (_) {
       if (!mounted) {
         return;
@@ -273,6 +275,7 @@ class _ReelTextState extends State<ReelText>
     InlineSpan? richText,
     bool force = false,
   }) {
+    _validateReelTextOptions(options);
     final targetFrame = _ReelTextFrame(text, richText);
     if (_animationsDisabled) {
       _controller.stop();
@@ -355,6 +358,7 @@ class _ReelTextState extends State<ReelText>
 
   @override
   Widget build(BuildContext context) {
+    _validateReelTextOptions(widget.options);
     final direction = widget.textDirection ??
         Directionality.maybeOf(context) ??
         TextDirection.ltr;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.4.1
+version: 0.4.2
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -4116,6 +4116,53 @@ void main() {
     },
   );
 
+  testWidgets('invalid custom waiting options preserve the active loop', (
+    tester,
+  ) async {
+    final controller = ReelTextController(initialText: 'Sync');
+    addTearDown(controller.dispose);
+    final active = controller.startWaiting(
+      'Sync',
+      waiting: const ReelWaiting.ellipsis(
+        step: Duration(milliseconds: 50),
+      ),
+    );
+    const invalidOptions = ReelTextOptions(
+      duration: Duration(microseconds: -1),
+    );
+
+    expect(
+      () => controller.startWaiting(
+        'Build',
+        waiting: ReelWaiting.builder(
+          (text, tick) => '$text$tick',
+          step: const Duration(milliseconds: 50),
+        ),
+        options: invalidOptions,
+      ),
+      throwsArgumentError,
+    );
+    expect(active.isActive, isTrue);
+    expect(controller.value, 'Sync');
+
+    expect(
+      () => controller.startWaiting(
+        'Scramble',
+        waiting: const ReelWaiting.scramble(
+          step: Duration(milliseconds: 50),
+        ),
+        options: invalidOptions,
+      ),
+      throwsArgumentError,
+    );
+    expect(active.isActive, isTrue);
+    expect(controller.value, 'Sync');
+
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.value, 'Sync.');
+    active.cancel();
+  });
+
   testWidgets('snaps without rolling when animations are disabled', (
     tester,
   ) async {

--- a/test/reel_text_test.dart
+++ b/test/reel_text_test.dart
@@ -48,6 +48,80 @@ void main() {
     expect(plain.reversed().direction, ReelTextDirection.down);
   });
 
+  test('animation options reject negative durations', () {
+    final controller = ReelTextController(initialText: 'One');
+    addTearDown(controller.dispose);
+
+    expect(
+      () => controller.set(
+        'Two',
+        options: const ReelTextOptions(
+          stagger: Duration(microseconds: -1),
+        ),
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => controller.set(
+        'Two',
+        options: const ReelTextOptions(
+          duration: Duration(microseconds: -1),
+        ),
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => controller.set(
+        'Two',
+        options: const ReelTextOptions(
+          exitOffset: Duration(microseconds: -1),
+        ),
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => controller.set(
+        'Two',
+        options: const ReelTextOptions(
+          colorFade: Duration(microseconds: -1),
+        ),
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => controller.flash(
+        'Two',
+        options: const ReelTextFlashOptions(
+          revertAfter: Duration(microseconds: -1),
+        ),
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('controller progress rejects non-positive intervals', () {
+    final controller = ReelTextController(initialText: 'One');
+    addTearDown(controller.dispose);
+    expect(
+      () => controller.startProgress('One', interval: Duration.zero),
+      throwsArgumentError,
+    );
+  });
+
+  testWidgets('sequence rejects non-positive intervals', (tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReelText.sequence(
+          values: ['One', 'Two'],
+          interval: Duration.zero,
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isArgumentError);
+  });
+
   testWidgets('renders settled text without animation on first build', (
     tester,
   ) async {
@@ -3685,6 +3759,53 @@ void main() {
     expect(find.bySemanticsLabel('one'), findsNothing);
     expect(find.bySemanticsLabel('two'), findsNothing);
     expect(find.bySemanticsLabel('three'), findsNothing);
+  });
+
+  testWidgets('switching controllers discards the previous pending target', (
+    tester,
+  ) async {
+    final first = ReelTextController(initialText: 'first');
+    final second = ReelTextController(initialText: 'second');
+    addTearDown(first.dispose);
+    addTearDown(second.dispose);
+    var active = first;
+    late StateSetter rebuild;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return ReelText.controller(controller: active);
+          },
+        ),
+      ),
+    );
+
+    const queuedOptions = ReelTextOptions(
+      duration: Duration(milliseconds: 80),
+      stagger: Duration.zero,
+      exitOffset: Duration.zero,
+      interrupt: false,
+    );
+    first.set('first-active', options: queuedOptions);
+    first.set('first-stale', options: queuedOptions);
+
+    rebuild(() => active = second);
+    await tester.pump();
+    second.set(
+      'second-final',
+      options: const ReelTextOptions(
+        duration: Duration(milliseconds: 20),
+        stagger: Duration.zero,
+        exitOffset: Duration.zero,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('second-final'), findsOneWidget);
+    expect(find.bySemanticsLabel('first-stale'), findsNothing);
   });
 
   testWidgets('controller set cancels a pending flash revert', (tester) async {


### PR DESCRIPTION
## Summary

- release the controller and measurement reliability fixes as `reel_text` 0.4.2
- dispose temporary `TextPainter` instances on success and failure paths
- discard pending transitions when switching `ReelTextController` instances
- validate animation durations, timer intervals, and bounce values before mutating controller state
- include the merged example dependency update from #30 (`google_fonts` 8.2.0)
- add regression coverage and release notes

## Why

The measurement path retained its temporary `TextPainter`, controller replacement could leave a target queued by the previous controller, and invalid timing values were accepted until lower-level Flutter APIs failed. These changes make those ownership and transition boundaries explicit while preserving the current public API.

## Impact

Invalid timing input now fails consistently with `ArgumentError` at the API consumption boundary. Valid animations and the visual rendering model are unchanged.

## Release

- bumped `pubspec.yaml` and the example lockfile to 0.4.2
- added the 0.4.2 changelog entry
- synchronized the branch with `main` after merging Dependabot PR #30

## Validation

- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` — 101 tests
- `flutter test --platform chrome` — 101 tests
- `cd example && flutter analyze`
- `cd example && flutter test` — 28 tests
- `git diff --check`
- `dart pub publish --dry-run` — 0 warnings
- `flutter build macos --debug`
- launched the fresh macOS example and visually checked Home, Editor, and PERF; exercised the Editor transition from `Ready` to `Invite copied` in active and settled states