### PR TITLE
Prepare 0.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.4
+
+- Added a concise, copy-ready example for the pub.dev Example tab while
+  preserving the full interactive showcase as the default example app.
+- No public API changes.
+
 ## 0.4.3
 
 - Reused up to four recent text measurements across recurring rolls, reducing

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,7 @@
 # reel_text example
 
-Interactive Flutter example app for the `reel_text` package.
+`example.md` contains the concise usage example displayed on pub.dev.
+`lib/main.dart` runs the full interactive showcase deployed to GitHub Pages.
 
 This app has its own SDK constraint and dependencies in this directory. The
 package compatibility floor is defined by the root `pubspec.yaml`.
@@ -30,7 +31,7 @@ flutter drive \
   -d macos
 ```
 
-Run it with:
+Run the interactive showcase with:
 
 ```bash
 flutter run

--- a/example/example.md
+++ b/example/example.md
@@ -1,0 +1,52 @@
+# Basic example
+
+`ReelText` animates automatically whenever its text changes:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:reel_text/reel_text.dart';
+
+void main() => runApp(const ReelTextExample());
+
+class ReelTextExample extends StatefulWidget {
+  const ReelTextExample({super.key});
+
+  @override
+  State<ReelTextExample> createState() => _ReelTextExampleState();
+}
+
+class _ReelTextExampleState extends State<ReelTextExample> {
+  var _count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        appBar: AppBar(title: const Text('reel_text example')),
+        body: Center(
+          child: ReelText(
+            '$_count',
+            options: const ReelTextOptions(
+              direction: ReelTextDirection.up,
+            ),
+            style: const TextStyle(
+              fontSize: 64,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => setState(() => _count++),
+          tooltip: 'Increment',
+          child: const Icon(Icons.add),
+        ),
+      ),
+    );
+  }
+}
+```
+
+See the [interactive showcase](https://kicknext.github.io/reel_text/) for more
+patterns, including async labels, button feedback, sequences, rich text, and
+editable replacements.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -381,7 +381,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.3"
+    version: "0.4.4"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reel_text
 description: A tactile Flutter text roll animation for tiny labels, counters, status text, and command buttons.
-version: 0.4.3
+version: 0.4.4
 homepage: https://kicknext.github.io/reel_text/
 repository: https://github.com/KickNext/reel_text
 issue_tracker: https://github.com/KickNext/reel_text/issues


### PR DESCRIPTION
## Summary

- add a concise, copy-ready `example/example.md` for the pub.dev Example tab
- keep the full interactive showcase as the default Flutter example app
- bump the package and example lockfile to `0.4.4`
- document the example split and add release notes

## Why

pub.dev currently falls through to `example/lib/main.dart`, so the Example tab renders the full showcase entrypoint instead of a focused usage sample. The recognized `example/example.md` file has higher selection priority and fixes the package onboarding experience without changing the demo application.

## Impact

Documentation and packaging metadata only. There are no public API or runtime behavior changes.

## Validation

- `flutter analyze`
- `flutter test` (103 tests)
- `flutter analyze` from `example/`
- `flutter test` from `example/` (24 tests)
- `dart pub publish --dry-run` (0 warnings)